### PR TITLE
feat: MemoとTagモデルの追加

### DIFF
--- a/frontend/analysis_options.yaml
+++ b/frontend/analysis_options.yaml
@@ -7,3 +7,8 @@ linter:
 analyzer:
   plugins:
     - custom_lint
+  errors:
+    invalid_annotation_target: ignore
+
+  exclude:
+    - "**/*.g.dart"

--- a/frontend/lib/models/memo.dart
+++ b/frontend/lib/models/memo.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:frontend/models/tag.dart';
+
+part 'memo.freezed.dart';
+part 'memo.g.dart';
+
+extension type const MemoId(int value) {}
+
+@freezed
+sealed class Memo with _$Memo {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory Memo({
+    @MemoIdJsonConverter() required MemoId id,
+    required String title,
+    required String body,
+    required DateTime createdAt,
+    @Default([]) List<Tag> tags,
+    DateTime? updatedAt,
+  }) = _Memo;
+
+  factory Memo.fromJson(Map<String, dynamic> json) => _$MemoFromJson(json);
+}
+
+final class MemoIdJsonConverter implements JsonConverter<MemoId, int> {
+  const MemoIdJsonConverter();
+
+  @override
+  MemoId fromJson(int json) => MemoId(json);
+
+  @override
+  int toJson(MemoId object) => object.value;
+}

--- a/frontend/lib/models/memo.dart
+++ b/frontend/lib/models/memo.dart
@@ -13,6 +13,7 @@ sealed class Memo with _$Memo {
     @MemoIdJsonConverter() required MemoId id,
     required String title,
     required String body,
+    required String raw,
     required DateTime createdAt,
     @Default([]) List<Tag> tags,
     DateTime? updatedAt,

--- a/frontend/lib/models/memo.freezed.dart
+++ b/frontend/lib/models/memo.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Memo {
 
-@MemoIdJsonConverter() MemoId get id; String get title; String get body; DateTime get createdAt; List<Tag> get tags; DateTime? get updatedAt;
+@MemoIdJsonConverter() MemoId get id; String get title; String get body; String get raw; DateTime get createdAt; List<Tag> get tags; DateTime? get updatedAt;
 /// Create a copy of Memo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $MemoCopyWith<Memo> get copyWith => _$MemoCopyWithImpl<Memo>(this as Memo, _$ide
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Memo&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.tags, tags)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Memo&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.raw, raw) || other.raw == raw)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.tags, tags)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,title,body,createdAt,const DeepCollectionEquality().hash(tags),updatedAt);
+int get hashCode => Object.hash(runtimeType,id,title,body,raw,createdAt,const DeepCollectionEquality().hash(tags),updatedAt);
 
 @override
 String toString() {
-  return 'Memo(id: $id, title: $title, body: $body, createdAt: $createdAt, tags: $tags, updatedAt: $updatedAt)';
+  return 'Memo(id: $id, title: $title, body: $body, raw: $raw, createdAt: $createdAt, tags: $tags, updatedAt: $updatedAt)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $MemoCopyWith<$Res>  {
   factory $MemoCopyWith(Memo value, $Res Function(Memo) _then) = _$MemoCopyWithImpl;
 @useResult
 $Res call({
-@MemoIdJsonConverter() MemoId id, String title, String body, DateTime createdAt, List<Tag> tags, DateTime? updatedAt
+@MemoIdJsonConverter() MemoId id, String title, String body, String raw, DateTime createdAt, List<Tag> tags, DateTime? updatedAt
 });
 
 
@@ -66,11 +66,12 @@ class _$MemoCopyWithImpl<$Res>
 
 /// Create a copy of Memo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? body = null,Object? createdAt = null,Object? tags = null,Object? updatedAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? body = null,Object? raw = null,Object? createdAt = null,Object? tags = null,Object? updatedAt = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MemoId,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,body: null == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String,raw: null == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,tags: null == tags ? _self.tags : tags // ignore: cast_nullable_to_non_nullable
 as List<Tag>,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
@@ -85,12 +86,13 @@ as DateTime?,
 
 @JsonSerializable(fieldRename: FieldRename.snake)
 class _Memo implements Memo {
-  const _Memo({@MemoIdJsonConverter() required this.id, required this.title, required this.body, required this.createdAt, final  List<Tag> tags = const [], this.updatedAt}): _tags = tags;
+  const _Memo({@MemoIdJsonConverter() required this.id, required this.title, required this.body, required this.raw, required this.createdAt, final  List<Tag> tags = const [], this.updatedAt}): _tags = tags;
   factory _Memo.fromJson(Map<String, dynamic> json) => _$MemoFromJson(json);
 
 @override@MemoIdJsonConverter() final  MemoId id;
 @override final  String title;
 @override final  String body;
+@override final  String raw;
 @override final  DateTime createdAt;
  final  List<Tag> _tags;
 @override@JsonKey() List<Tag> get tags {
@@ -114,16 +116,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Memo&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._tags, _tags)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Memo&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.raw, raw) || other.raw == raw)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._tags, _tags)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,title,body,createdAt,const DeepCollectionEquality().hash(_tags),updatedAt);
+int get hashCode => Object.hash(runtimeType,id,title,body,raw,createdAt,const DeepCollectionEquality().hash(_tags),updatedAt);
 
 @override
 String toString() {
-  return 'Memo(id: $id, title: $title, body: $body, createdAt: $createdAt, tags: $tags, updatedAt: $updatedAt)';
+  return 'Memo(id: $id, title: $title, body: $body, raw: $raw, createdAt: $createdAt, tags: $tags, updatedAt: $updatedAt)';
 }
 
 
@@ -134,7 +136,7 @@ abstract mixin class _$MemoCopyWith<$Res> implements $MemoCopyWith<$Res> {
   factory _$MemoCopyWith(_Memo value, $Res Function(_Memo) _then) = __$MemoCopyWithImpl;
 @override @useResult
 $Res call({
-@MemoIdJsonConverter() MemoId id, String title, String body, DateTime createdAt, List<Tag> tags, DateTime? updatedAt
+@MemoIdJsonConverter() MemoId id, String title, String body, String raw, DateTime createdAt, List<Tag> tags, DateTime? updatedAt
 });
 
 
@@ -151,11 +153,12 @@ class __$MemoCopyWithImpl<$Res>
 
 /// Create a copy of Memo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? body = null,Object? createdAt = null,Object? tags = null,Object? updatedAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? body = null,Object? raw = null,Object? createdAt = null,Object? tags = null,Object? updatedAt = freezed,}) {
   return _then(_Memo(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as MemoId,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,body: null == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String,raw: null == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,tags: null == tags ? _self._tags : tags // ignore: cast_nullable_to_non_nullable
 as List<Tag>,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable

--- a/frontend/lib/models/memo.freezed.dart
+++ b/frontend/lib/models/memo.freezed.dart
@@ -1,0 +1,169 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'memo.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Memo {
+
+@MemoIdJsonConverter() MemoId get id; String get title; String get body; DateTime get createdAt; List<Tag> get tags; DateTime? get updatedAt;
+/// Create a copy of Memo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MemoCopyWith<Memo> get copyWith => _$MemoCopyWithImpl<Memo>(this as Memo, _$identity);
+
+  /// Serializes this Memo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Memo&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other.tags, tags)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,body,createdAt,const DeepCollectionEquality().hash(tags),updatedAt);
+
+@override
+String toString() {
+  return 'Memo(id: $id, title: $title, body: $body, createdAt: $createdAt, tags: $tags, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MemoCopyWith<$Res>  {
+  factory $MemoCopyWith(Memo value, $Res Function(Memo) _then) = _$MemoCopyWithImpl;
+@useResult
+$Res call({
+@MemoIdJsonConverter() MemoId id, String title, String body, DateTime createdAt, List<Tag> tags, DateTime? updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$MemoCopyWithImpl<$Res>
+    implements $MemoCopyWith<$Res> {
+  _$MemoCopyWithImpl(this._self, this._then);
+
+  final Memo _self;
+  final $Res Function(Memo) _then;
+
+/// Create a copy of Memo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? body = null,Object? createdAt = null,Object? tags = null,Object? updatedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as MemoId,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,body: null == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,tags: null == tags ? _self.tags : tags // ignore: cast_nullable_to_non_nullable
+as List<Tag>,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class _Memo implements Memo {
+  const _Memo({@MemoIdJsonConverter() required this.id, required this.title, required this.body, required this.createdAt, final  List<Tag> tags = const [], this.updatedAt}): _tags = tags;
+  factory _Memo.fromJson(Map<String, dynamic> json) => _$MemoFromJson(json);
+
+@override@MemoIdJsonConverter() final  MemoId id;
+@override final  String title;
+@override final  String body;
+@override final  DateTime createdAt;
+ final  List<Tag> _tags;
+@override@JsonKey() List<Tag> get tags {
+  if (_tags is EqualUnmodifiableListView) return _tags;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_tags);
+}
+
+@override final  DateTime? updatedAt;
+
+/// Create a copy of Memo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MemoCopyWith<_Memo> get copyWith => __$MemoCopyWithImpl<_Memo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$MemoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Memo&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&const DeepCollectionEquality().equals(other._tags, _tags)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,body,createdAt,const DeepCollectionEquality().hash(_tags),updatedAt);
+
+@override
+String toString() {
+  return 'Memo(id: $id, title: $title, body: $body, createdAt: $createdAt, tags: $tags, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MemoCopyWith<$Res> implements $MemoCopyWith<$Res> {
+  factory _$MemoCopyWith(_Memo value, $Res Function(_Memo) _then) = __$MemoCopyWithImpl;
+@override @useResult
+$Res call({
+@MemoIdJsonConverter() MemoId id, String title, String body, DateTime createdAt, List<Tag> tags, DateTime? updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$MemoCopyWithImpl<$Res>
+    implements _$MemoCopyWith<$Res> {
+  __$MemoCopyWithImpl(this._self, this._then);
+
+  final _Memo _self;
+  final $Res Function(_Memo) _then;
+
+/// Create a copy of Memo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? body = null,Object? createdAt = null,Object? tags = null,Object? updatedAt = freezed,}) {
+  return _then(_Memo(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as MemoId,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,body: null == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,tags: null == tags ? _self._tags : tags // ignore: cast_nullable_to_non_nullable
+as List<Tag>,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/frontend/lib/models/memo.g.dart
+++ b/frontend/lib/models/memo.g.dart
@@ -10,6 +10,7 @@ _Memo _$MemoFromJson(Map<String, dynamic> json) => _Memo(
   id: const MemoIdJsonConverter().fromJson((json['id'] as num).toInt()),
   title: json['title'] as String,
   body: json['body'] as String,
+  raw: json['raw'] as String,
   createdAt: DateTime.parse(json['created_at'] as String),
   tags:
       (json['tags'] as List<dynamic>?)
@@ -26,6 +27,7 @@ Map<String, dynamic> _$MemoToJson(_Memo instance) => <String, dynamic>{
   'id': const MemoIdJsonConverter().toJson(instance.id),
   'title': instance.title,
   'body': instance.body,
+  'raw': instance.raw,
   'created_at': instance.createdAt.toIso8601String(),
   'tags': instance.tags,
   'updated_at': instance.updatedAt?.toIso8601String(),

--- a/frontend/lib/models/memo.g.dart
+++ b/frontend/lib/models/memo.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'memo.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Memo _$MemoFromJson(Map<String, dynamic> json) => _Memo(
+  id: const MemoIdJsonConverter().fromJson((json['id'] as num).toInt()),
+  title: json['title'] as String,
+  body: json['body'] as String,
+  createdAt: DateTime.parse(json['created_at'] as String),
+  tags:
+      (json['tags'] as List<dynamic>?)
+          ?.map((e) => Tag.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
+  updatedAt:
+      json['updated_at'] == null
+          ? null
+          : DateTime.parse(json['updated_at'] as String),
+);
+
+Map<String, dynamic> _$MemoToJson(_Memo instance) => <String, dynamic>{
+  'id': const MemoIdJsonConverter().toJson(instance.id),
+  'title': instance.title,
+  'body': instance.body,
+  'created_at': instance.createdAt.toIso8601String(),
+  'tags': instance.tags,
+  'updated_at': instance.updatedAt?.toIso8601String(),
+};

--- a/frontend/lib/models/memo_preview.dart
+++ b/frontend/lib/models/memo_preview.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:frontend/models/memo.dart';
+
+part 'memo_preview.freezed.dart';
+part 'memo_preview.g.dart';
+
+@freezed
+sealed class MemoPreview with _$MemoPreview {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory MemoPreview({
+    @MemoIdJsonConverter() required MemoId id,
+    required String title,
+    required String body,
+    required DateTime createdAt,
+    DateTime? updatedAt,
+  }) = _MemoPreview;
+
+  factory MemoPreview.fromJson(Map<String, dynamic> json) =>
+      _$MemoPreviewFromJson(json);
+}

--- a/frontend/lib/models/memo_preview.freezed.dart
+++ b/frontend/lib/models/memo_preview.freezed.dart
@@ -1,0 +1,160 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'memo_preview.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$MemoPreview {
+
+@MemoIdJsonConverter() MemoId get id; String get title; String get body; DateTime get createdAt; DateTime? get updatedAt;
+/// Create a copy of MemoPreview
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MemoPreviewCopyWith<MemoPreview> get copyWith => _$MemoPreviewCopyWithImpl<MemoPreview>(this as MemoPreview, _$identity);
+
+  /// Serializes this MemoPreview to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MemoPreview&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,body,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'MemoPreview(id: $id, title: $title, body: $body, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MemoPreviewCopyWith<$Res>  {
+  factory $MemoPreviewCopyWith(MemoPreview value, $Res Function(MemoPreview) _then) = _$MemoPreviewCopyWithImpl;
+@useResult
+$Res call({
+@MemoIdJsonConverter() MemoId id, String title, String body, DateTime createdAt, DateTime? updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$MemoPreviewCopyWithImpl<$Res>
+    implements $MemoPreviewCopyWith<$Res> {
+  _$MemoPreviewCopyWithImpl(this._self, this._then);
+
+  final MemoPreview _self;
+  final $Res Function(MemoPreview) _then;
+
+/// Create a copy of MemoPreview
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? body = null,Object? createdAt = null,Object? updatedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as MemoId,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,body: null == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class _MemoPreview implements MemoPreview {
+  const _MemoPreview({@MemoIdJsonConverter() required this.id, required this.title, required this.body, required this.createdAt, this.updatedAt});
+  factory _MemoPreview.fromJson(Map<String, dynamic> json) => _$MemoPreviewFromJson(json);
+
+@override@MemoIdJsonConverter() final  MemoId id;
+@override final  String title;
+@override final  String body;
+@override final  DateTime createdAt;
+@override final  DateTime? updatedAt;
+
+/// Create a copy of MemoPreview
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MemoPreviewCopyWith<_MemoPreview> get copyWith => __$MemoPreviewCopyWithImpl<_MemoPreview>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$MemoPreviewToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MemoPreview&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,body,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'MemoPreview(id: $id, title: $title, body: $body, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MemoPreviewCopyWith<$Res> implements $MemoPreviewCopyWith<$Res> {
+  factory _$MemoPreviewCopyWith(_MemoPreview value, $Res Function(_MemoPreview) _then) = __$MemoPreviewCopyWithImpl;
+@override @useResult
+$Res call({
+@MemoIdJsonConverter() MemoId id, String title, String body, DateTime createdAt, DateTime? updatedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$MemoPreviewCopyWithImpl<$Res>
+    implements _$MemoPreviewCopyWith<$Res> {
+  __$MemoPreviewCopyWithImpl(this._self, this._then);
+
+  final _MemoPreview _self;
+  final $Res Function(_MemoPreview) _then;
+
+/// Create a copy of MemoPreview
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? body = null,Object? createdAt = null,Object? updatedAt = freezed,}) {
+  return _then(_MemoPreview(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as MemoId,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,body: null == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/frontend/lib/models/memo_preview.g.dart
+++ b/frontend/lib/models/memo_preview.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'memo_preview.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_MemoPreview _$MemoPreviewFromJson(Map<String, dynamic> json) => _MemoPreview(
+  id: const MemoIdJsonConverter().fromJson((json['id'] as num).toInt()),
+  title: json['title'] as String,
+  body: json['body'] as String,
+  createdAt: DateTime.parse(json['created_at'] as String),
+  updatedAt:
+      json['updated_at'] == null
+          ? null
+          : DateTime.parse(json['updated_at'] as String),
+);
+
+Map<String, dynamic> _$MemoPreviewToJson(_MemoPreview instance) =>
+    <String, dynamic>{
+      'id': const MemoIdJsonConverter().toJson(instance.id),
+      'title': instance.title,
+      'body': instance.body,
+      'created_at': instance.createdAt.toIso8601String(),
+      'updated_at': instance.updatedAt?.toIso8601String(),
+    };

--- a/frontend/lib/models/tag.dart
+++ b/frontend/lib/models/tag.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'tag.freezed.dart';
+part 'tag.g.dart';
+
+extension type const TagId(int value) {}
+
+@freezed
+sealed class Tag with _$Tag {
+  const factory Tag({
+    @TagIdJsonConverter() required TagId id,
+    required String name,
+  }) = _Tag;
+
+  factory Tag.fromJson(Map<String, dynamic> json) => _$TagFromJson(json);
+}
+
+final class TagIdJsonConverter implements JsonConverter<TagId, int> {
+  const TagIdJsonConverter();
+
+  @override
+  TagId fromJson(int json) => TagId(json);
+
+  @override
+  int toJson(TagId object) => object.value;
+}

--- a/frontend/lib/models/tag.freezed.dart
+++ b/frontend/lib/models/tag.freezed.dart
@@ -1,0 +1,151 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'tag.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Tag {
+
+@TagIdJsonConverter() TagId get id; String get name;
+/// Create a copy of Tag
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TagCopyWith<Tag> get copyWith => _$TagCopyWithImpl<Tag>(this as Tag, _$identity);
+
+  /// Serializes this Tag to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Tag&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name);
+
+@override
+String toString() {
+  return 'Tag(id: $id, name: $name)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TagCopyWith<$Res>  {
+  factory $TagCopyWith(Tag value, $Res Function(Tag) _then) = _$TagCopyWithImpl;
+@useResult
+$Res call({
+@TagIdJsonConverter() TagId id, String name
+});
+
+
+
+
+}
+/// @nodoc
+class _$TagCopyWithImpl<$Res>
+    implements $TagCopyWith<$Res> {
+  _$TagCopyWithImpl(this._self, this._then);
+
+  final Tag _self;
+  final $Res Function(Tag) _then;
+
+/// Create a copy of Tag
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as TagId,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _Tag implements Tag {
+  const _Tag({@TagIdJsonConverter() required this.id, required this.name});
+  factory _Tag.fromJson(Map<String, dynamic> json) => _$TagFromJson(json);
+
+@override@TagIdJsonConverter() final  TagId id;
+@override final  String name;
+
+/// Create a copy of Tag
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TagCopyWith<_Tag> get copyWith => __$TagCopyWithImpl<_Tag>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TagToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Tag&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name);
+
+@override
+String toString() {
+  return 'Tag(id: $id, name: $name)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TagCopyWith<$Res> implements $TagCopyWith<$Res> {
+  factory _$TagCopyWith(_Tag value, $Res Function(_Tag) _then) = __$TagCopyWithImpl;
+@override @useResult
+$Res call({
+@TagIdJsonConverter() TagId id, String name
+});
+
+
+
+
+}
+/// @nodoc
+class __$TagCopyWithImpl<$Res>
+    implements _$TagCopyWith<$Res> {
+  __$TagCopyWithImpl(this._self, this._then);
+
+  final _Tag _self;
+  final $Res Function(_Tag) _then;
+
+/// Create a copy of Tag
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,}) {
+  return _then(_Tag(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as TagId,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/frontend/lib/models/tag.g.dart
+++ b/frontend/lib/models/tag.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'tag.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Tag _$TagFromJson(Map<String, dynamic> json) => _Tag(
+  id: const TagIdJsonConverter().fromJson((json['id'] as num).toInt()),
+  name: json['name'] as String,
+);
+
+Map<String, dynamic> _$TagToJson(_Tag instance) => <String, dynamic>{
+  'id': const TagIdJsonConverter().toJson(instance.id),
+  'name': instance.name,
+};

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -283,8 +283,16 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
@@ -372,13 +380,21 @@ packages:
     source: hosted
     version: "0.7.2"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -560,6 +576,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.5"
   source_span:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   hooks_riverpod: ^2.6.1
   flutter_hooks: ^0.21.2
   riverpod_annotation: ^2.6.1
+  freezed_annotation: ^3.0.0
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   build_runner: ^2.4.15
@@ -44,6 +46,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  freezed: ^3.0.6
+  json_serializable: ^6.9.5
   riverpod_generator: ^2.6.5
   riverpod_lint: ^2.6.5
   very_good_analysis: ^7.0.0


### PR DESCRIPTION
## 確認してほしいこと
- 各モデルクラスが良さそうか

## 備考
- `.g.dart`や`.freezed.dart`は生成されたファイルです。
- freezedというパッケージを使い、不変性を担保することで保守性をあげています。
  - `copyWith`や`fromJson`などの便利なメソッドも自動で生成してくれます。
- サーバはsnake_caseっぽいので、`JsonSerializable`で`FieldRename`の設定をしています。（CamelCase⇔snake_case）
- 保守性を上げるため、MemoのPKはintではなくMemoId（extension type）を用いています。
  - これでintとMemoIdが区別され保守性があがります。（DDD的思想）

## 参考
- [freezed | Dart package](https://pub.dev/packages/freezed)
- [Extension types | Dart](https://dart.dev/language/extension-types)