### PR TITLE
Feat memo repository

### DIFF
--- a/frontend/lib/providers/repository_provider.dart
+++ b/frontend/lib/providers/repository_provider.dart
@@ -1,0 +1,11 @@
+import 'package:frontend/repositories/memo_repository/in_memory_memo_repository.dart';
+import 'package:frontend/repositories/memo_repository/memo_repository.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'repository_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+MemoRepository memoRepository(Ref ref) {
+  return InMemoryMemoRepository(); // 本番環境では実装を差し替える
+}

--- a/frontend/lib/providers/repository_provider.g.dart
+++ b/frontend/lib/providers/repository_provider.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'repository_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$memoRepositoryHash() => r'a110590bdca376ee0787315e5b2cc8aa243e8152';
+
+/// See also [memoRepository].
+@ProviderFor(memoRepository)
+final memoRepositoryProvider = Provider<MemoRepository>.internal(
+  memoRepository,
+  name: r'memoRepositoryProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$memoRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef MemoRepositoryRef = ProviderRef<MemoRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
@@ -6,6 +6,8 @@ import 'package:frontend/repositories/memo_repository/memo_repository.dart';
 
 /// メモのリポジトリのインメモリ実装。Dockerを起動しない場合のデバッグ時のみ使用する。
 class InMemoryMemoRepository implements MemoRepository {
+  static const int _pickTagsCount = 2;
+
   final Map<MemoId, Memo> _memos = {};
   final Map<TagId, Tag> _tags = {
     const TagId(0): const Tag(id: TagId(0), name: 'tag1'),
@@ -92,6 +94,6 @@ class InMemoryMemoRepository implements MemoRepository {
   // タグ選択の仮実装
   List<Tag> _pickTags() {
     final shuffled = _tags.values.toList()..shuffle();
-    return shuffled.sublist(0, 2); // 2つのタグをランダムに選択
+    return shuffled.sublist(0, _pickTagsCount); // タグをランダムに選択
   }
 }

--- a/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
@@ -10,11 +10,11 @@ class InMemoryMemoRepository implements MemoRepository {
 
   final Map<MemoId, Memo> _memos = {};
   final Map<TagId, Tag> _tags = {
-    const TagId(0): const Tag(id: TagId(0), name: 'tag1'),
-    const TagId(1): const Tag(id: TagId(1), name: 'tag2'),
-    const TagId(2): const Tag(id: TagId(2), name: 'tag3'),
+    const TagId(1): const Tag(id: TagId(1), name: 'tag1'),
+    const TagId(2): const Tag(id: TagId(2), name: 'tag2'),
+    const TagId(3): const Tag(id: TagId(3), name: 'tag3'),
   };
-  int _idHeader = 0;
+  int _nextId = 0;
 
   @override
   Future<List<MemoPreview>> getMemos() async =>
@@ -36,10 +36,10 @@ class InMemoryMemoRepository implements MemoRepository {
 
   @override
   Future<void> addMemo(String rawMemo) async {
-    final memoId = MemoId(++_idHeader);
+    final memoId = MemoId(++_nextId);
     _memos[memoId] = Memo(
       id: memoId,
-      title: 'Memo $_idHeader',
+      title: 'Memo $_nextId',
       body: '$rawMemoの要約',
       raw: rawMemo,
       createdAt: DateTime.now(),

--- a/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
@@ -1,0 +1,97 @@
+import 'package:collection/collection.dart';
+import 'package:frontend/models/memo.dart';
+import 'package:frontend/models/memo_preview.dart';
+import 'package:frontend/models/tag.dart';
+import 'package:frontend/repositories/memo_repository/memo_repository.dart';
+
+/// メモのリポジトリのインメモリ実装。Dockerを起動しない場合のデバッグ時のみ使用する。
+class InMemoryMemoRepository implements MemoRepository {
+  final Map<MemoId, Memo> _memos = {};
+  final Map<TagId, Tag> _tags = {
+    const TagId(0): const Tag(id: TagId(0), name: 'tag1'),
+    const TagId(1): const Tag(id: TagId(1), name: 'tag2'),
+    const TagId(2): const Tag(id: TagId(2), name: 'tag3'),
+  };
+  int _idHeader = 0;
+
+  @override
+  Future<List<MemoPreview>> getMemos() async =>
+      _memos.values
+          .map(
+            (memo) => MemoPreview(
+              id: memo.id,
+              title: memo.title,
+              body: memo.body,
+              createdAt: memo.createdAt,
+              updatedAt: memo.updatedAt,
+            ),
+          )
+          .toList();
+
+  @override
+  Future<Memo> getMemoById(MemoId id) async =>
+      _memos[id] ?? (throw MemoNotFoundException(id));
+
+  @override
+  Future<void> addMemo(String rawMemo) async {
+    final memoId = MemoId(++_idHeader);
+    _memos[memoId] = Memo(
+      id: memoId,
+      title: 'Memo $_idHeader',
+      body: '$rawMemoの要約',
+      raw: rawMemo,
+      createdAt: DateTime.now(),
+      tags: _pickTags(),
+    );
+  }
+
+  @override
+  Future<void> updateMemoTitle(MemoId id, String newTitle) => _updateMemo(
+    id,
+    (memo) => memo.copyWith(title: newTitle, updatedAt: DateTime.now()),
+  );
+
+  @override
+  Future<void> updateMemoBody(MemoId id, String newBody) => _updateMemo(
+    id,
+    (memo) => memo.copyWith(body: newBody, updatedAt: DateTime.now()),
+  );
+
+  @override
+  Future<void> updateMemoTags(MemoId id, List<String> newTags) {
+    final updatedTags =
+        newTags.map((tagName) {
+          final existingTag = _tags.values.firstWhereOrNull(
+            (tag) => tag.name == tagName,
+          );
+          if (existingTag != null) return existingTag;
+          final newId = TagId(_tags.length);
+          final newTag = Tag(id: newId, name: tagName);
+          _tags[newId] = newTag;
+          return newTag;
+        }).toList();
+
+    return _updateMemo(
+      id,
+      (memo) => memo.copyWith(tags: updatedTags, updatedAt: DateTime.now()),
+    );
+  }
+
+  @override
+  Future<void> deleteMemo(MemoId id) async {
+    if (_memos.remove(id) == null) throw MemoNotFoundException(id);
+  }
+
+  // メモの更新処理を共通化、非同期処理にしている
+  Future<void> _updateMemo(MemoId id, Memo Function(Memo) update) async {
+    final memo = _memos[id];
+    if (memo == null) throw MemoNotFoundException(id);
+    _memos[id] = update(memo);
+  }
+
+  // タグ選択の仮実装
+  List<Tag> _pickTags() {
+    final shuffled = _tags.values.toList()..shuffle();
+    return shuffled.sublist(0, 2); // 2つのタグをランダムに選択
+  }
+}

--- a/frontend/lib/repositories/memo_repository/memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/memo_repository.dart
@@ -1,0 +1,35 @@
+import 'package:frontend/models/memo.dart';
+import 'package:frontend/models/memo_preview.dart';
+
+abstract interface class MemoRepository {
+  /// メモの一覧を取得する
+  ///
+  /// TODO: 引数にクエリ系のパラメータを追加。サーバーの実装に合わせてenumなどを用意する
+  Future<List<MemoPreview>> getMemos();
+
+  /// メモのIDからメモを取得する
+  Future<Memo> getMemoById(MemoId id);
+
+  /// メモを追加する。文字起こしなどの文字列を引数に取る
+  Future<void> addMemo(String rawMemo);
+
+  /// メモのタイトルを更新する
+  Future<void> updateMemoTitle(MemoId id, String newTitle);
+
+  /// メモの本文を更新する
+  Future<void> updateMemoBody(MemoId id, String newBody);
+
+  /// メモのタグを更新する
+  Future<void> updateMemoTags(MemoId id, List<String> newTags);
+
+  /// メモを削除する
+  Future<void> deleteMemo(MemoId id);
+}
+
+class MemoNotFoundException implements Exception {
+  MemoNotFoundException(this.id);
+  final MemoId id;
+
+  @override
+  String toString() => 'Memo with id $id not found';
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -162,7 +162,7 @@ packages:
     source: hosted
     version: "4.10.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   gpt_markdown: ^1.0.19
+  collection: ^1.19.1
 
 dev_dependencies:
   build_runner: ^2.4.15

--- a/frontend/test/repositories/memo_repository_test.dart
+++ b/frontend/test/repositories/memo_repository_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frontend/models/memo.dart';
+import 'package:frontend/repositories/memo_repository/in_memory_memo_repository.dart';
+import 'package:frontend/repositories/memo_repository/memo_repository.dart';
+
+void main() {
+  group('MemoRepository', () {
+    late MemoRepository repository;
+
+    setUp(() {
+      repository = InMemoryMemoRepository();
+    });
+
+    test('getMemos returns empty list initially', () async {
+      final memos = await repository.getMemos();
+      expect(memos, isEmpty);
+    });
+
+    test('addMemo adds a memo and getMemos returns it', () async {
+      await repository.addMemo('テストメモ');
+
+      final memos = await repository.getMemos();
+
+      expect(memos.length, 1);
+      expect(memos.first.title, 'Memo 1');
+      expect(memos.first.body, 'テストメモの要約');
+    });
+
+    test('getMemoById returns correct memo', () async {
+      await repository.addMemo('テストメモ1');
+      await repository.addMemo('テストメモ2');
+
+      final memo = await repository.getMemoById(const MemoId(2));
+
+      expect(memo.id, const MemoId(2));
+      expect(memo.title, 'Memo 2');
+      expect(memo.body, 'テストメモ2の要約');
+      expect(memo.raw, 'テストメモ2');
+      expect(memo.tags, isNotEmpty);
+    });
+
+    test(
+      'getMemoById throws MemoNotFoundException for non-existent memo',
+      () async {
+        await repository.addMemo('テストメモ');
+
+        expect(
+          () => repository.getMemoById(const MemoId(99)),
+          throwsA(isA<MemoNotFoundException>()),
+        );
+      },
+    );
+
+    test('updateMemoTitle updates title', () async {
+      await repository.addMemo('テストメモ');
+      await repository.updateMemoTitle(const MemoId(1), '新しいタイトル');
+
+      final memo = await repository.getMemoById(const MemoId(1));
+
+      expect(memo.title, '新しいタイトル');
+      expect(memo.updatedAt, isNotNull);
+    });
+
+    test('updateMemoBody updates body', () async {
+      await repository.addMemo('テストメモ');
+      await repository.updateMemoBody(const MemoId(1), '新しい要約');
+
+      final memo = await repository.getMemoById(const MemoId(1));
+
+      expect(memo.body, '新しい要約');
+      expect(memo.updatedAt, isNotNull);
+    });
+
+    test('updateMemoTags updates tags with existing and new tags', () async {
+      await repository.addMemo('テストメモ');
+
+      // 既存のタグと新しいタグを混ぜて更新
+      await repository.updateMemoTags(const MemoId(1), ['tag1', '新しいタグ']);
+
+      final memo = await repository.getMemoById(const MemoId(1));
+
+      expect(memo.tags.length, 2);
+      expect(memo.tags.map((tag) => tag.name), contains('tag1'));
+      expect(memo.tags.map((tag) => tag.name), contains('新しいタグ'));
+      expect(memo.updatedAt, isNotNull);
+    });
+
+    test('deleteMemo removes the memo', () async {
+      await repository.addMemo('テストメモ1');
+      await repository.addMemo('テストメモ2');
+
+      await repository.deleteMemo(const MemoId(1));
+
+      final memos = await repository.getMemos();
+
+      expect(memos.length, 1);
+      expect(memos.first.id, const MemoId(2));
+
+      expect(
+        () => repository.getMemoById(const MemoId(1)),
+        throwsA(isA<MemoNotFoundException>()),
+      );
+    });
+
+    test(
+      'deleteMemo throws MemoNotFoundException for non-existent memo',
+      () async {
+        expect(
+          () => repository.deleteMemo(const MemoId(99)),
+          throwsA(isA<MemoNotFoundException>()),
+        );
+      },
+    );
+
+    test(
+      'updateMemoTitle throws MemoNotFoundException for non-existent memo',
+      () async {
+        expect(
+          () => repository.updateMemoTitle(const MemoId(99), '新しいタイトル'),
+          throwsA(isA<MemoNotFoundException>()),
+        );
+      },
+    );
+
+    test(
+      'updateMemoBody throws MemoNotFoundException for non-existent memo',
+      () async {
+        expect(
+          () => repository.updateMemoBody(const MemoId(99), '新しい要約'),
+          throwsA(isA<MemoNotFoundException>()),
+        );
+      },
+    );
+
+    test(
+      'updateMemoTags throws MemoNotFoundException for non-existent memo',
+      () async {
+        expect(
+          () => repository.updateMemoTags(const MemoId(99), ['tag1']),
+          throwsA(isA<MemoNotFoundException>()),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
close #147 
relate #146 

## 確認してほしいこと
- `MemoRepository`インタフェース

## 備考
- #82 の実装を少し変更したものです 
- getMemosはMemoRepositoryに含むようにしました
- getMemosは検索系のクエリの引数を取るようになる想定ですが、今回は含めませんでした