### PR TITLE
feat: メモ情報の更新

### DIFF
--- a/backend/crud/memo.py
+++ b/backend/crud/memo.py
@@ -1,5 +1,11 @@
 from typing import List, Optional
 
+from crud.memotag import (
+    add_memotags_by_tags,
+    delete_memotags_by_tags,
+    fetch_tag_ids_by_memo_id,
+)
+from crud.tag import fetch_tag_ids_by_names, upsert_tags
 from models.memo import Memos
 from sqlalchemy.orm import Session
 
@@ -12,3 +18,43 @@ def fetch_memos(db: Session, user_id: str, search_word: Optional[str] = None):
         query = query.filter(Memos.title.ilike(f"%{search_word}%"))
 
     return query.all()
+
+
+def update_memo_by_id(
+    db: Session,
+    user_id: str,
+    memo_id: int,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+    tag_names: Optional[List[str]] = None,
+):
+    query = db.query(Memos)
+    query = query.filter(Memos.user_id == user_id)
+    query = query.filter(Memos.id == memo_id)
+    memo = query.one_or_none()
+
+    if memo is None:
+        return None
+
+    if title is not None:
+        memo.title = title
+
+    if body is not None:
+        memo.body = body
+
+    if tag_names is not None:
+        upsert_tags(db, tag_names)
+        new_tag_ids = fetch_tag_ids_by_names(db, tag_names)
+        current_tag_ids = fetch_tag_ids_by_memo_id(db, memo_id)
+
+        tags_to_delete = current_tag_ids - new_tag_ids
+        tags_to_add = new_tag_ids - current_tag_ids
+
+        if tags_to_delete:
+            delete_memotags_by_tags(db, memo_id, tags_to_delete)
+
+        if tags_to_add:
+            add_memotags_by_tags(db, memo_id, tags_to_add)
+
+    db.commit()
+    return memo

--- a/backend/crud/memo.py
+++ b/backend/crud/memo.py
@@ -7,17 +7,19 @@ from crud.memotag import (
 )
 from crud.tag import fetch_tag_ids_by_names, upsert_tags
 from models.memo import Memos
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 
 def fetch_memos(db: Session, user_id: str, search_word: Optional[str] = None):
-    query = db.query(Memos)
-    query = query.filter(Memos.user_id == user_id)
+    query = select(Memos)
+    query = query.where(Memos.user_id == user_id)
 
     if search_word:
-        query = query.filter(Memos.title.ilike(f"%{search_word}%"))
+        query = query.where(Memos.title.ilike(f"%{search_word}%"))
 
-    return query.all()
+    result = db.execute(query)
+    return result.scalars().all()
 
 
 def update_memo_by_id(
@@ -28,10 +30,12 @@ def update_memo_by_id(
     body: Optional[str] = None,
     tag_names: Optional[List[str]] = None,
 ):
-    query = db.query(Memos)
-    query = query.filter(Memos.user_id == user_id)
-    query = query.filter(Memos.id == memo_id)
-    memo = query.one_or_none()
+    query = select(Memos)
+    query = query.where(Memos.user_id == user_id)
+    query = query.where(Memos.id == memo_id)
+
+    result = db.execute(query)
+    memo = result.scalars().one_or_none()
 
     if memo is None:
         return None

--- a/backend/crud/memotag.py
+++ b/backend/crud/memotag.py
@@ -1,0 +1,21 @@
+from models.memotag import MemoTags
+from sqlalchemy.orm import Session
+
+
+def fetch_tag_ids_by_memo_id(db: Session, memo_id: int):
+    query = db.query(MemoTags.tag_id)
+    query = query.filter(MemoTags.memo_id == memo_id)
+    query = query.scalars()
+    return set(query.all())
+
+
+def delete_memotags_by_tags(db: Session, memo_id: int, tags_to_delete: set):
+    query = db.query(MemoTags)
+    query = query.filter(MemoTags.memo_id == memo_id)
+    query = query.filter(MemoTags.tag_id.in_(tags_to_delete))
+    query.delete(synchronize_session=False)
+
+
+def add_memotags_by_tags(db: Session, memo_id: int, tags_to_add: set):
+    new_tags_list = [{"memo_id": memo_id, "tag_id": tag_id} for tag_id in tags_to_add]
+    db.bulk_insert_mappings(MemoTags, new_tags_list)

--- a/backend/crud/memotag.py
+++ b/backend/crud/memotag.py
@@ -1,19 +1,21 @@
 from models.memotag import MemoTags
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 
 def fetch_tag_ids_by_memo_id(db: Session, memo_id: int):
-    query = db.query(MemoTags.tag_id)
-    query = query.filter(MemoTags.memo_id == memo_id)
-    query = query.scalars()
-    return set(query.all())
+    query = select(MemoTags.tag_id)
+    query = query.where(MemoTags.memo_id == memo_id)
+    result = db.execute(query)
+    tag_ids = result.scalars()
+    return set(tag_ids.all())
 
 
 def delete_memotags_by_tags(db: Session, memo_id: int, tags_to_delete: set):
-    query = db.query(MemoTags)
-    query = query.filter(MemoTags.memo_id == memo_id)
-    query = query.filter(MemoTags.tag_id.in_(tags_to_delete))
-    query.delete(synchronize_session=False)
+    query = delete(MemoTags)
+    query = query.where(MemoTags.memo_id == memo_id)
+    query = query.where(MemoTags.tag_id.in_(tags_to_delete))
+    db.execute(query)
 
 
 def add_memotags_by_tags(db: Session, memo_id: int, tags_to_add: set):

--- a/backend/crud/tag.py
+++ b/backend/crud/tag.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import List, Optional
 
 from models.memo import Memos
 from models.memotag import MemoTags
 from models.tag import Tags
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
 
@@ -18,3 +19,18 @@ def fetch_tags(db: Session, user_id: str, search_word: Optional[str] = None):
     query = query.distinct()
 
     return query.all()
+
+
+def upsert_tags(db: Session, tag_names: List[str]):
+    query = insert(Tags)
+    query = query.values([{"name": name} for name in tag_names])
+    query = query.on_conflict_do_nothing(index_elements=["name"])
+    db.execute(query)
+    db.flush()
+
+
+def fetch_tag_ids_by_names(db: Session, tag_names: List[str]):
+    query = db.query(Tags.id)
+    query = query.filter(Tags.name.in_(tag_names))
+    query = query.scalars()
+    return set(query.all())

--- a/backend/crud/tag.py
+++ b/backend/crud/tag.py
@@ -3,34 +3,39 @@ from typing import List, Optional
 from models.memo import Memos
 from models.memotag import MemoTags
 from models.tag import Tags
+from sqlalchemy import distinct, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
 
 def fetch_tags(db: Session, user_id: str, search_word: Optional[str] = None):
-    query = db.query(Tags)
-
-    if search_word:
-        query = query.filter(Tags.name.ilike(f"%{search_word}%"))
-
+    query = select(Tags)
+    query = query.distinct()
     query = query.join(MemoTags, Tags.id == MemoTags.tag_id)
     query = query.join(Memos, Memos.id == MemoTags.memo_id)
-    query = query.filter(Memos.user_id == user_id)
-    query = query.distinct()
+    query = query.where(Memos.user_id == user_id)
 
-    return query.all()
+    if search_word:
+        query = query.where(Tags.name.ilike(f"%{search_word}%"))
+
+    result = db.execute(query)
+
+    return result.scalars().all()
 
 
 def upsert_tags(db: Session, tag_names: List[str]):
     query = insert(Tags)
     query = query.values([{"name": name} for name in tag_names])
     query = query.on_conflict_do_nothing(index_elements=["name"])
+
     db.execute(query)
     db.flush()
 
 
 def fetch_tag_ids_by_names(db: Session, tag_names: List[str]):
-    query = db.query(Tags.id)
-    query = query.filter(Tags.name.in_(tag_names))
-    query = query.scalars()
-    return set(query.all())
+    query = select(Tags.id)
+    query = query.where(Tags.name.in_(tag_names))
+
+    result = db.execute(query)
+
+    return set(result.scalars().all())

--- a/backend/models/tag.py
+++ b/backend/models/tag.py
@@ -8,6 +8,6 @@ from sqlalchemy.orm import relationship
 class Tags(Base):
     __tablename__ = "tags"
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String, nullable=False)
+    name = Column(String, nullable=False, unique=True)
 
     memos = relationship("MemoTags", back_populates="tag")

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -5,7 +5,12 @@ from crud.memo import fetch_memos, update_memo_by_id
 from database import get_db
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from schemas.auth import DecodedToken
-from schemas.memo import MemoPreviewResponse
+from schemas.memo import (
+    MemoBodyUpdateRequest,
+    MemoPreviewResponse,
+    MemoTagsUpdateRequest,
+    MemoTitleUpdateRequest,
+)
 from sqlalchemy.orm import Session
 from starlette import status
 
@@ -31,8 +36,15 @@ async def read_root(
 
 
 @router.put("/{memo_id}/title", status_code=status.HTTP_200_OK)
-async def read_root(db: DbDependency, user: UserDependency, memo_id: int, title: str):
-    memo = update_memo_by_id(db=db, user_id=user.user_id, memo_id=memo_id, title=title)
+async def read_root(
+    db: DbDependency,
+    user: UserDependency,
+    memo_id: int,
+    request: MemoTitleUpdateRequest,
+):
+    memo = update_memo_by_id(
+        db=db, user_id=user.user_id, memo_id=memo_id, title=request.title
+    )
 
     if memo is None:
         raise HTTPException(status_code=404, detail="Memo not found")
@@ -41,8 +53,15 @@ async def read_root(db: DbDependency, user: UserDependency, memo_id: int, title:
 
 
 @router.put("/{memo_id}/body", status_code=status.HTTP_200_OK)
-async def read_root(db: DbDependency, user: UserDependency, memo_id: int, body: str):
-    memo = update_memo_by_id(db=db, user_id=user.user_id, memo_id=memo_id, body=body)
+async def read_root(
+    db: DbDependency,
+    user: UserDependency,
+    memo_id: int,
+    request: MemoBodyUpdateRequest,
+):
+    memo = update_memo_by_id(
+        db=db, user_id=user.user_id, memo_id=memo_id, body=request.body
+    )
 
     if memo is None:
         raise HTTPException(status_code=404, detail="Memo not found")
@@ -52,9 +71,14 @@ async def read_root(db: DbDependency, user: UserDependency, memo_id: int, body: 
 
 @router.put("/{memo_id}/tags", status_code=status.HTTP_200_OK)
 async def read_root(
-    db: DbDependency, user: UserDependency, memo_id: int, tags: List[int]
+    db: DbDependency,
+    user: UserDependency,
+    memo_id: int,
+    request: MemoTagsUpdateRequest,
 ):
-    memo = update_memo_by_id(db=db, user_id=user.user_id, memo_id=memo_id, tags=tags)
+    memo = update_memo_by_id(
+        db=db, user_id=user.user_id, memo_id=memo_id, tag_names=request.tag_names
+    )
 
     if memo is None:
         raise HTTPException(status_code=404, detail="Memo not found")

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -1,9 +1,9 @@
 from typing import Annotated, List, Optional
 
 from crud.auth import get_current_user
-from crud.memo import fetch_memos
+from crud.memo import fetch_memos, update_memo_by_id
 from database import get_db
-from fastapi import APIRouter, Depends, Header, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from schemas.auth import DecodedToken
 from schemas.memo import MemoPreviewResponse
 from sqlalchemy.orm import Session
@@ -28,3 +28,35 @@ async def read_root(
 ):
     memos = fetch_memos(db=db, user_id=user.user_id, search_word=keyword)
     return [MemoPreviewResponse.model_validate(m) for m in memos]
+
+
+@router.put("/{memo_id}/title", status_code=status.HTTP_200_OK)
+async def read_root(db: DbDependency, user: UserDependency, memo_id: int, title: str):
+    memo = update_memo_by_id(db=db, user_id=user.user_id, memo_id=memo_id, title=title)
+
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+
+    return
+
+
+@router.put("/{memo_id}/body", status_code=status.HTTP_200_OK)
+async def read_root(db: DbDependency, user: UserDependency, memo_id: int, body: str):
+    memo = update_memo_by_id(db=db, user_id=user.user_id, memo_id=memo_id, body=body)
+
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+
+    return
+
+
+@router.put("/{memo_id}/tags", status_code=status.HTTP_200_OK)
+async def read_root(
+    db: DbDependency, user: UserDependency, memo_id: int, tags: List[int]
+):
+    memo = update_memo_by_id(db=db, user_id=user.user_id, memo_id=memo_id, tags=tags)
+
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+
+    return

--- a/backend/schemas/memo.py
+++ b/backend/schemas/memo.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import List
 
 from pydantic import BaseModel, Field
 
@@ -10,5 +11,23 @@ class MemoPreviewResponse(BaseModel):
     body: str = Field(min_length=1, examples=["Body"])
     created_at: datetime
     updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class MemoTitleUpdateRequest(BaseModel):
+    title: str
+
+    model_config = {"from_attributes": True}
+
+
+class MemoBodyUpdateRequest(BaseModel):
+    body: str
+
+    model_config = {"from_attributes": True}
+
+
+class MemoTagsUpdateRequest(BaseModel):
+    tag_names: List[str]
 
     model_config = {"from_attributes": True}

--- a/backend/tests/test_put_memo_by_id.py
+++ b/backend/tests/test_put_memo_by_id.py
@@ -1,0 +1,177 @@
+import pytest
+from models.memo import Memos
+from models.memotag import MemoTags
+from models.tag import Tags
+from tests.mock_data.memo import EMPTY_MEMOS, SHORT_MEMOS
+from tests.mock_data.memotag import EMPTY_MEMOTAGS, SHORT_MEMOTAGS
+from tests.mock_data.tag import EMPTY_TAGS, SHORT_TAGS
+from tests.utils.auth import get_headers
+from tests.utils.post import create_test_memos, create_test_memotags, create_test_tags
+
+
+# 指定したメモが正常に変更されるか(title)
+def test_normal_update_title(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    title = "成功"
+
+    response = client.put(
+        f"/memos/{memo_id}/title", headers=headers, json={"title": title}
+    )
+    assert response.status_code == 200
+
+    updated_memo = (
+        test_db.query(Memos).filter_by(id=memo_id, user_id=user_id).one_or_none()
+    )
+    assert updated_memo is not None
+
+    assert updated_memo.title == title
+
+
+# 存在しないメモを指定した場合に正常に通信が行われるか(title)
+def test_empty_memo_title(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, EMPTY_MEMOS)
+
+    memo_id = 1
+    title = "失敗"
+
+    response = client.put(
+        f"/memos/{memo_id}/title", headers=headers, json={"title": title}
+    )
+    assert response.status_code == 404
+
+
+# 異なるユーザのメモを指定した場合に正常に通信が行われるか(title)
+def test_failure_id_title(test_db, client):
+    user_id = "b"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    title = "失敗"
+
+    response = client.put(
+        f"/memos/{memo_id}/title", headers=headers, json={"title": title}
+    )
+    assert response.status_code == 404
+
+
+# 指定したメモが正常に変更されるか(body)
+def test_normal_update_body(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    body = "成功"
+
+    response = client.put(
+        f"/memos/{memo_id}/body", headers=headers, json={"body": body}
+    )
+    assert response.status_code == 200
+
+    updated_memo = (
+        test_db.query(Memos).filter_by(id=memo_id, user_id=user_id).one_or_none()
+    )
+    assert updated_memo is not None
+
+    assert updated_memo.body == body
+
+
+# 存在しないメモを指定した場合に正常に通信が行われるか(body)
+def test_empty_memo_body(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, EMPTY_MEMOS)
+
+    memo_id = 1
+    body = "失敗"
+
+    response = client.put(
+        f"/memos/{memo_id}/body", headers=headers, json={"body": body}
+    )
+    assert response.status_code == 404
+
+
+# 異なるユーザのメモを指定した場合に正常に通信が行われるか(body)
+def test_failure_id_body(test_db, client):
+    user_id = "b"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    body = "失敗"
+
+    response = client.put(
+        f"/memos/{memo_id}/body", headers=headers, json={"body": body}
+    )
+    assert response.status_code == 404
+
+
+# 指定したメモが正常に変更されるか(tags)
+def test_normal_update_title(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+    create_test_tags(test_db, SHORT_TAGS)
+    create_test_memotags(test_db, SHORT_MEMOTAGS)
+    create_test_tags
+
+    memo_id = 1
+    tag_names = ["成功", "タグ1", "タグ3"]
+
+    response = client.put(
+        f"/memos/{memo_id}/tags", headers=headers, json={"tag_names": tag_names}
+    )
+    assert response.status_code == 200
+
+    updated_memotags = test_db.query(MemoTags).filter_by(memo_id=memo_id).all()
+    assert len(updated_memotags) == 3
+
+    updated_tags = (
+        test_db.query(Tags)
+        .join(MemoTags, MemoTags.tag_id == Tags.id)
+        .filter(MemoTags.memo_id == memo_id)
+        .all()
+    )
+
+    assert len(updated_tags) == 3
+
+    for tag in updated_tags:
+        assert tag.name in tag_names
+        assert tag.name != "Tag 2"
+
+
+# 存在しないメモを指定した場合に正常に通信が行われるか(tags)
+def test_empty_memo_body(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, EMPTY_MEMOS)
+
+    memo_id = 1
+    tag_names = ["失敗"]
+
+    response = client.put(
+        f"/memos/{memo_id}/tags", headers=headers, json={"tag_names": tag_names}
+    )
+    assert response.status_code == 404
+
+
+# 異なるユーザのメモを指定した場合に正常に通信が行われるか(tags)
+def test_failure_id_body(test_db, client):
+    user_id = "b"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    tag_names = ["失敗"]
+
+    response = client.put(
+        f"/memos/{memo_id}/tags", headers=headers, json={"tag_names": tag_names}
+    )
+    assert response.status_code == 404

--- a/docs/openai.yaml
+++ b/docs/openai.yaml
@@ -184,7 +184,7 @@ paths:
         '422':
           description: リクエストが不正
 
-  /memos/{memo_id}/tag:
+  /memos/{memo_id}/tags:
     put:
       summary: メモのタグ修正
       parameters:
@@ -204,12 +204,12 @@ paths:
           application/json:
             schema:
               type: object
-              required: [tags]
+              required: [tag_names]
               properties:
                 tags:
                   type: array
                   items:
-                    type: string
+                    type: str
       responses:
         '200':
           description: なし


### PR DESCRIPTION
relate: #26
close: #154 

## 実施内容
- PUT /memos/{memo_id}/title, body, tagsの実装
- 既にマージされたエンドポイントのリファクタリング

## 補足
- どうやらdb.queryを使うのは古い実装だったらしく，selectやdeleteに置き換え
- 現時点でマージされていないものは，別issueでリファクタリングを実施予定