### PR TITLE
Feat memo title dropdown

### DIFF
--- a/frontend/lib/constant.dart
+++ b/frontend/lib/constant.dart
@@ -1,0 +1,2 @@
+// TODO: 適切な値に修正する
+const memoTitleMaxLength = 15;

--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/tag.dart';
 import 'package:frontend/providers/memo_provider.dart';
+import 'package:frontend/widgets/memo_details/memo_title_menu.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -30,7 +31,7 @@ class MemoDetailsPage extends ConsumerWidget {
     final memo = memoAsyncValue.requireValue;
 
     return Scaffold(
-      appBar: AppBar(title: Text(memo.title)),
+      appBar: AppBar(title: MemoTitleMenu(memo: memo)),
       body: DefaultTabController(
         length: MemoDetailsTab.values.length,
         child: SafeArea(

--- a/frontend/lib/widgets/dialogs/delete_dialog.dart
+++ b/frontend/lib/widgets/dialogs/delete_dialog.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class DeleteDialog extends StatelessWidget {
+  const DeleteDialog({required this.title, super.key});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: const Text('この操作は取り消せません。'),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop(false);
+          },
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop(true);
+          },
+          child: const Text('削除'),
+        ),
+      ],
+    );
+  }
+}
+
+class MemoDeleteDialog extends StatelessWidget {
+  const MemoDeleteDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const DeleteDialog(title: 'このメモを削除しますか？');
+  }
+}

--- a/frontend/lib/widgets/dialogs/input_dialog.dart
+++ b/frontend/lib/widgets/dialogs/input_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:frontend/constant.dart';
 
 class InputDialog extends HookWidget {
   const InputDialog({
@@ -8,6 +9,7 @@ class InputDialog extends HookWidget {
     this.hintText,
     this.initialValue,
     this.validator,
+    this.maxLength,
     super.key,
   });
 
@@ -16,6 +18,7 @@ class InputDialog extends HookWidget {
   final String? initialValue;
   final String? Function(String?)? validator;
   final String actionLabel;
+  final int? maxLength;
 
   @override
   Widget build(BuildContext context) {
@@ -27,10 +30,14 @@ class InputDialog extends HookWidget {
       content: Form(
         key: formKey,
         child: TextFormField(
+          maxLength: maxLength,
           validator: validator,
           autofocus: true,
           controller: textController,
-          decoration: InputDecoration(hintText: hintText),
+          decoration: InputDecoration(
+            hintText: hintText,
+            border: const OutlineInputBorder(),
+          ),
         ),
       ),
       actions: [
@@ -65,6 +72,7 @@ class MemoTitleUpdateDialog extends StatelessWidget {
       actionLabel: '変更',
       hintText: 'メモのタイトル',
       initialValue: initialValue,
+      maxLength: memoTitleMaxLength,
       validator: (value) {
         if (value == null || value.isEmpty) {
           return 'タイトルを入力してください';

--- a/frontend/lib/widgets/dialogs/input_dialog.dart
+++ b/frontend/lib/widgets/dialogs/input_dialog.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class InputDialog extends HookWidget {
+  const InputDialog({
+    required this.title,
+    required this.actionLabel,
+    this.hintText,
+    this.initialValue,
+    this.validator,
+    super.key,
+  });
+
+  final String title;
+  final String? hintText;
+  final String? initialValue;
+  final String? Function(String?)? validator;
+  final String actionLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final formKey = useMemoized(GlobalKey<FormState>.new);
+    final textController = useTextEditingController(text: initialValue);
+
+    return AlertDialog(
+      title: Text(title),
+      content: Form(
+        key: formKey,
+        child: TextFormField(
+          validator: validator,
+          autofocus: true,
+          controller: textController,
+          decoration: InputDecoration(hintText: hintText),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed: () {
+            if (formKey.currentState?.validate() ?? false) {
+              Navigator.of(context).pop(textController.text);
+            }
+          },
+          child: Text(actionLabel),
+        ),
+      ],
+    );
+  }
+}
+
+class MemoTitleUpdateDialog extends StatelessWidget {
+  const MemoTitleUpdateDialog({required this.initialValue, super.key});
+
+  final String initialValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDialog(
+      title: 'タイトルを編集',
+      actionLabel: '変更',
+      hintText: 'メモのタイトル',
+      initialValue: initialValue,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return 'タイトルを入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}

--- a/frontend/lib/widgets/dialogs/input_dialog.dart
+++ b/frontend/lib/widgets/dialogs/input_dialog.dart
@@ -60,8 +60,8 @@ class InputDialog extends HookWidget {
   }
 }
 
-class MemoTitleUpdateDialog extends StatelessWidget {
-  const MemoTitleUpdateDialog({required this.initialValue, super.key});
+class MemoTitleInputDialog extends StatelessWidget {
+  const MemoTitleInputDialog({required this.initialValue, super.key});
 
   final String initialValue;
 

--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -45,12 +45,12 @@ class MemoTitleMenu extends StatelessWidget {
           borderRadius: BorderRadius.circular(16),
           onTap: () => controller.open(),
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            padding: const EdgeInsets.all(8),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               spacing: 8,
               children: [
-                const SizedBox(width: 16),
+                const SizedBox(width: 16), // バランスを取るためのスペース
                 child!,
                 const Icon(Icons.arrow_drop_down),
               ],

--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -13,21 +13,23 @@ class MemoTitleMenu extends StatelessWidget {
     return MenuAnchor(
       style: const MenuStyle(alignment: Alignment.bottomCenter),
       menuChildren: [
-        MenuItemButton(
-          child: const _MenuActionItem(icon: Icons.edit, label: 'タイトル編集'),
+        _MenuItemButton(
+          icon: Icons.edit,
+          label: 'タイトル編集',
           onPressed: () async {
             final newTitle = await showDialog<String>(
               context: context,
               builder:
-                  (context) => MemoTitleUpdateDialog(initialValue: memo.title),
+                  (context) => MemoTitleInputDialog(initialValue: memo.title),
             );
             if (newTitle != null) {
               // TODO(tyPhoon-collab): メモタイトル更新の処理を実装する
             }
           },
         ),
-        MenuItemButton(
-          child: const _MenuActionItem(icon: Icons.delete, label: '削除'),
+        _MenuItemButton(
+          icon: Icons.delete,
+          label: '削除',
           onPressed: () async {
             final isDeletionSelected = await showDialog<bool>(
               context: context,
@@ -65,18 +67,23 @@ class MemoTitleMenu extends StatelessWidget {
   }
 }
 
-class _MenuActionItem extends StatelessWidget {
-  const _MenuActionItem({required this.icon, required this.label});
+class _MenuItemButton extends StatelessWidget {
+  const _MenuItemButton({
+    required this.icon,
+    required this.label,
+    this.onPressed,
+  });
 
   final IconData icon;
   final String label;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      spacing: 8,
-      mainAxisSize: MainAxisSize.min,
-      children: [Icon(icon), Text(label)],
+    return MenuItemButton(
+      leadingIcon: Icon(icon),
+      onPressed: onPressed,
+      child: Text(label),
     );
   }
 }

--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -10,36 +10,35 @@ class MemoTitleMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Future<void> updateTitle() async {
+      final newTitle = await showDialog<String>(
+        context: context,
+        builder: (context) => MemoTitleInputDialog(initialValue: memo.title),
+      );
+      if (newTitle != null) {
+        // TODO(tyPhoon-collab): メモタイトル更新の処理を実装する
+      }
+    }
+
+    Future<void> delete() async {
+      final isDeletionSelected = await showDialog<bool>(
+        context: context,
+        builder: (context) => const MemoDeleteDialog(),
+      );
+      if (isDeletionSelected ?? false) {
+        // TODO(tyPhoon-collab): メモ削除の処理を実装する
+      }
+    }
+
     return MenuAnchor(
       style: const MenuStyle(alignment: Alignment.bottomCenter),
       menuChildren: [
         _MenuItemButton(
           icon: Icons.edit,
           label: 'タイトル編集',
-          onPressed: () async {
-            final newTitle = await showDialog<String>(
-              context: context,
-              builder:
-                  (context) => MemoTitleInputDialog(initialValue: memo.title),
-            );
-            if (newTitle != null) {
-              // TODO(tyPhoon-collab): メモタイトル更新の処理を実装する
-            }
-          },
+          onPressed: updateTitle,
         ),
-        _MenuItemButton(
-          icon: Icons.delete,
-          label: '削除',
-          onPressed: () async {
-            final isDeletionSelected = await showDialog<bool>(
-              context: context,
-              builder: (context) => const MemoDeleteDialog(),
-            );
-            if (isDeletionSelected ?? false) {
-              // TODO(tyPhoon-collab): メモ削除の処理を実装する
-            }
-          },
-        ),
+        _MenuItemButton(icon: Icons.delete, label: '削除', onPressed: delete),
       ],
       builder: (context, controller, child) {
         return InkWell(

--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/models/memo.dart';
+import 'package:frontend/widgets/dialogs/delete_dialog.dart';
+import 'package:frontend/widgets/dialogs/input_dialog.dart';
+
+class MemoTitleMenu extends StatelessWidget {
+  const MemoTitleMenu({required this.memo, super.key});
+
+  final Memo memo;
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuAnchor(
+      style: const MenuStyle(alignment: Alignment.bottomCenter),
+      menuChildren: [
+        MenuItemButton(
+          child: const _MenuActionItem(icon: Icons.edit, label: 'タイトル編集'),
+          onPressed: () async {
+            final newTitle = await showDialog<String>(
+              context: context,
+              builder:
+                  (context) => MemoTitleUpdateDialog(initialValue: memo.title),
+            );
+            if (newTitle != null) {
+              // TODO(tyPhoon-collab): メモタイトル更新の処理を実装する
+            }
+          },
+        ),
+        MenuItemButton(
+          child: const _MenuActionItem(icon: Icons.delete, label: '削除'),
+          onPressed: () async {
+            final isDeletionSelected = await showDialog<bool>(
+              context: context,
+              builder: (context) => const MemoDeleteDialog(),
+            );
+            if (isDeletionSelected ?? false) {
+              // TODO(tyPhoon-collab): メモ削除の処理を実装する
+            }
+          },
+        ),
+      ],
+      builder: (context, controller, child) {
+        return InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: () => controller.open(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                const SizedBox(width: 16),
+                child!,
+                const Icon(Icons.arrow_drop_down),
+              ],
+            ),
+          ),
+        );
+      },
+      child: Text(
+        memo.title,
+        style: const TextStyle(overflow: TextOverflow.fade),
+      ),
+    );
+  }
+}
+
+class _MenuActionItem extends StatelessWidget {
+  const _MenuActionItem({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      spacing: 8,
+      mainAxisSize: MainAxisSize.min,
+      children: [Icon(icon), Text(label)],
+    );
+  }
+}


### PR DESCRIPTION
close #84 
relate #22 

タイトルドロップダウンの実装
Dialogは再利用性を意識してクラスを分割（InputDialog、DeleteDialog）
API接続は別issue

<img width="406" alt="image" src="https://github.com/user-attachments/assets/9a9f599a-d4d4-42bd-a742-2ed7423d60b7" />
<img width="365" alt="image" src="https://github.com/user-attachments/assets/12e7953e-83da-4ac2-94db-2d598b3f3c98" />
<img width="365" alt="image" src="https://github.com/user-attachments/assets/2585719c-d23a-4a9e-a389-5a3db1e08e82" />
