### PR TITLE
feat: メモ追加導線のFAB実装

### DIFF
--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -58,7 +58,8 @@ class MemoListViewPage extends HookWidget {
               Expanded(
                 child: Scrollbar(
                   child: ListView.separated(
-                    padding: const EdgeInsets.only(bottom: 20),
+                    // FABの分大きめにpaddingをとる
+                    padding: const EdgeInsets.only(bottom: 160),
                     separatorBuilder:
                         (context, index) => const SizedBox(height: 20),
                     itemCount: mockMemoList.length,

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -59,7 +59,7 @@ class MemoListViewPage extends HookWidget {
                 child: Scrollbar(
                   child: ListView.separated(
                     // FABの分大きめにpaddingをとる
-                    padding: const EdgeInsets.only(bottom: 160),
+                    padding: const EdgeInsets.only(bottom: 180),
                     separatorBuilder:
                         (context, index) => const SizedBox(height: 20),
                     itemCount: mockMemoList.length,
@@ -95,7 +95,7 @@ class _AddMemoFab extends HookWidget {
       curve: Curves.easeOut,
     );
     final editButtonAnimation = Tween<Offset>(
-      begin: const Offset(0, 2.5),
+      begin: const Offset(0, 2.9),
       end: Offset.zero,
     ).animate(slideAnimation);
     final micButtonAnimation = Tween<Offset>(
@@ -126,7 +126,7 @@ class _AddMemoFab extends HookWidget {
             child: const Icon(Icons.edit),
           ),
         ),
-        const SizedBox(height: 5),
+        const SizedBox(height: 10),
         SlideTransition(
           position: micButtonAnimation,
           child: FloatingActionButton(
@@ -143,7 +143,7 @@ class _AddMemoFab extends HookWidget {
           ),
         ),
 
-        const SizedBox(height: 10),
+        const SizedBox(height: 20),
 
         FloatingActionButton(
           backgroundColor:

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/memo_preview.dart';
 import 'package:frontend/widgets/destination_navigation_drawer.dart';
+import 'package:frontend/widgets/dialogs/record_dialog.dart';
 import 'package:frontend/widgets/memo_card.dart';
 
 class MemoListViewPage extends StatelessWidget {
@@ -22,13 +24,103 @@ class MemoListViewPage extends StatelessWidget {
     return Scaffold(
       drawer: const DestinationNavigationDrawer(),
       appBar: AppBar(title: const Text('メモ一覧')),
+      floatingActionButton: const _AddMemoFab(),
       body: ListView(
+        // TODO(Rozelin-dc): FABに被らないようにpaddingを調整
         children: [
           ...mockMemoList.map(
             (memoPreview) => MemoCard(memoPreview: memoPreview),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _AddMemoFab extends HookWidget {
+  const _AddMemoFab();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final isOpen = useState(false);
+
+    const animationDuration = Duration(milliseconds: 300);
+    final animationController = useAnimationController(
+      duration: animationDuration,
+    );
+    final slideAnimation = CurvedAnimation(
+      parent: animationController,
+      curve: Curves.easeOut,
+    );
+    final editButtonAnimation = Tween<Offset>(
+      begin: const Offset(0, 2.5),
+      end: Offset.zero,
+    ).animate(slideAnimation);
+    final micButtonAnimation = Tween<Offset>(
+      begin: const Offset(0, 1.5),
+      end: Offset.zero,
+    ).animate(slideAnimation);
+    useEffect(() {
+      if (isOpen.value) {
+        animationController.forward();
+      } else {
+        animationController.reverse();
+      }
+      return null;
+    }, [isOpen.value]);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SlideTransition(
+          position: editButtonAnimation,
+          child: FloatingActionButton(
+            heroTag: 'add-memo-text-fab',
+            mini: true,
+            onPressed: () {
+              // TODO(Rozelin-dc): メモ追加のダイアログ表示
+              debugPrint('メモ追加');
+            },
+            child: const Icon(Icons.edit),
+          ),
+        ),
+        const SizedBox(height: 5),
+        SlideTransition(
+          position: micButtonAnimation,
+          child: FloatingActionButton(
+            heroTag: 'add-memo-voice-fab',
+            mini: true,
+            onPressed: () async {
+              final transcription = await pickTranscribed(context);
+              if (transcription == null) return;
+
+              // TODO(Rozelin-dc): メモ追加処理
+              debugPrint('音声メモ追加: $transcription');
+            },
+            child: const Icon(Icons.mic),
+          ),
+        ),
+
+        const SizedBox(height: 10),
+
+        FloatingActionButton(
+          backgroundColor:
+              isOpen.value
+                  ? theme.colorScheme.secondaryContainer
+                  : theme.colorScheme.primary,
+          foregroundColor:
+              isOpen.value
+                  ? theme.colorScheme.onSecondaryContainer
+                  : theme.colorScheme.onPrimary,
+          onPressed: () => isOpen.value = !isOpen.value,
+          child: RotationTransition(
+            turns: animationController,
+            child: Icon(isOpen.value ? Icons.close : Icons.add),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -88,37 +88,16 @@ class _AddMemoFab extends HookWidget {
     final isOpen = useState(false);
 
     const animationDuration = Duration(milliseconds: 300);
-    final animationController = useAnimationController(
-      duration: animationDuration,
-    );
-    final slideAnimation = CurvedAnimation(
-      parent: animationController,
-      curve: Curves.easeOut,
-    );
-    final editButtonAnimation = Tween<Offset>(
-      begin: const Offset(0, 2.9),
-      end: Offset.zero,
-    ).animate(slideAnimation);
-    final micButtonAnimation = Tween<Offset>(
-      begin: const Offset(0, 1.5),
-      end: Offset.zero,
-    ).animate(slideAnimation);
-    useEffect(() {
-      if (isOpen.value) {
-        animationController.forward();
-      } else {
-        animationController.reverse();
-      }
-      return null;
-    }, [isOpen.value]);
+    const animationCurve = Curves.easeOut;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SlideTransition(
-          position: editButtonAnimation,
+        AnimatedSlide(
+          offset: isOpen.value ? Offset.zero : const Offset(0, 2.9),
+          duration: animationDuration,
+          curve: animationCurve,
           child: FloatingActionButton(
-            heroTag: 'add-memo-text-fab',
             mini: true,
             onPressed: () async {
               final rawMemo = await showDialog<String>(
@@ -134,10 +113,11 @@ class _AddMemoFab extends HookWidget {
           ),
         ),
         const SizedBox(height: 10),
-        SlideTransition(
-          position: micButtonAnimation,
+        AnimatedSlide(
+          offset: isOpen.value ? Offset.zero : const Offset(0, 1.6),
+          duration: animationDuration,
+          curve: animationCurve,
           child: FloatingActionButton(
-            heroTag: 'add-memo-voice-fab',
             mini: true,
             onPressed: () async {
               final transcription = await pickTranscribed(context);
@@ -162,8 +142,10 @@ class _AddMemoFab extends HookWidget {
                   ? theme.colorScheme.onSecondaryContainer
                   : theme.colorScheme.onPrimary,
           onPressed: () => isOpen.value = !isOpen.value,
-          child: RotationTransition(
-            turns: animationController,
+          child: AnimatedRotation(
+            turns: isOpen.value ? 0.5 : 0,
+            duration: animationDuration,
+            curve: animationCurve,
             child: Icon(isOpen.value ? Icons.close : Icons.add),
           ),
         ),

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -97,8 +97,8 @@ class _AddMemoFab extends HookWidget {
           offset: isOpen.value ? Offset.zero : const Offset(0, 2.9),
           duration: animationDuration,
           curve: animationCurve,
-          child: FloatingActionButton(
-            mini: true,
+          child: FloatingActionButton.small(
+            heroTag: null,
             onPressed: () async {
               final rawMemo = await showDialog<String>(
                 context: context,
@@ -117,8 +117,8 @@ class _AddMemoFab extends HookWidget {
           offset: isOpen.value ? Offset.zero : const Offset(0, 1.6),
           duration: animationDuration,
           curve: animationCurve,
-          child: FloatingActionButton(
-            mini: true,
+          child: FloatingActionButton.small(
+            heroTag: null,
             onPressed: () async {
               final transcription = await pickTranscribed(context);
               if (transcription == null) return;

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -4,6 +4,7 @@ import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/memo_preview.dart';
 import 'package:frontend/models/tag.dart';
 import 'package:frontend/widgets/destination_navigation_drawer.dart';
+import 'package:frontend/widgets/dialogs/input_dialog.dart';
 import 'package:frontend/widgets/dialogs/record_dialog.dart';
 import 'package:frontend/widgets/memo_card.dart';
 
@@ -119,9 +120,15 @@ class _AddMemoFab extends HookWidget {
           child: FloatingActionButton(
             heroTag: 'add-memo-text-fab',
             mini: true,
-            onPressed: () {
-              // TODO(Rozelin-dc): メモ追加のダイアログ表示
-              debugPrint('メモ追加');
+            onPressed: () async {
+              final rawMemo = await showDialog<String>(
+                context: context,
+                builder: (context) => const AddMemoFromTextDialog(),
+              );
+              if (rawMemo != null) {
+                // TODO(Rozelin-dc): メモ追加処理
+                debugPrint('テキストメモ追加: $rawMemo');
+              }
             },
             child: const Icon(Icons.edit),
           ),

--- a/frontend/lib/widgets/dialogs/input_dialog.dart
+++ b/frontend/lib/widgets/dialogs/input_dialog.dart
@@ -10,6 +10,7 @@ class InputDialog extends HookWidget {
     this.initialValue,
     this.validator,
     this.maxLength,
+    this.expandsWithInputText = false,
     super.key,
   });
 
@@ -19,6 +20,7 @@ class InputDialog extends HookWidget {
   final String? Function(String?)? validator;
   final String actionLabel;
   final int? maxLength;
+  final bool expandsWithInputText;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +33,7 @@ class InputDialog extends HookWidget {
         key: formKey,
         child: TextFormField(
           maxLength: maxLength,
+          maxLines: expandsWithInputText ? null : 1,
           validator: validator,
           autofocus: true,
           controller: textController,
@@ -76,6 +79,26 @@ class MemoTitleInputDialog extends StatelessWidget {
       validator: (value) {
         if (value == null || value.isEmpty) {
           return 'タイトルを入力してください';
+        }
+        return null;
+      },
+    );
+  }
+}
+
+class AddMemoFromTextDialog extends StatelessWidget {
+  const AddMemoFromTextDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDialog(
+      title: 'メモを追加',
+      actionLabel: '追加',
+      hintText: 'メモの内容',
+      expandsWithInputText: true,
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return 'メモを入力してください';
         }
         return null;
       },


### PR DESCRIPTION
close #67 
relate #21 

## 概要
- メモ一覧画面にメモ追加導線となるFABを追加しました

![image](https://github.com/user-attachments/assets/18185328-79b9-4ae5-a523-fb44aec24823)![image](https://github.com/user-attachments/assets/c84bcc39-ea8b-45bf-857f-bdcc38f2c85a)

## 備考
- ~~#119 とのうち、先にマージされなかった方でListViewがFABに被らないようにpaddingの調整を行います~~
- ~~#159 でテキスト入力のできるダイアログを実装してくれているので、それがマージされたらeditボタンのアクションを実装します~~
- どちらも対応完了しました