### PR TITLE
feat: Websocketによる更新依頼

### DIFF
--- a/backend/crud/auth.py
+++ b/backend/crud/auth.py
@@ -66,5 +66,5 @@ def get_current_user_websocket(websocket: WebSocket):
         return DecodedToken(user_id=user_id)
     except JWTError:
         raise HTTPException(
-            status_code=HTTP_401_UNAUTHORIZED, detail="IInvalid Authorization"
+            status_code=HTTP_401_UNAUTHORIZED, detail="Invalid Authorization"
         )

--- a/backend/crud/auth.py
+++ b/backend/crud/auth.py
@@ -2,8 +2,9 @@ from datetime import datetime, timedelta
 from typing import Annotated
 
 from config import get_settings
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, WebSocket
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security.utils import get_authorization_scheme_param
 from jose import JWTError, jwt
 from schemas.auth import DecodedToken
 from starlette.status import HTTP_401_UNAUTHORIZED
@@ -36,4 +37,34 @@ def get_current_user(token: Annotated[HTTPAuthorizationCredentials, Depends(secu
     except JWTError:
         raise HTTPException(
             status_code=HTTP_401_UNAUTHORIZED, detail="Invalid Authorization"
+        )
+
+
+def get_current_user_websocket(websocket: WebSocket):
+    auth_header = websocket.headers.get("Authorization")
+    if not auth_header:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization",
+        )
+
+    scheme, token = get_authorization_scheme_param(auth_header)
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization",
+        )
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[SECRET_ALGORITHM])
+        user_id = payload.get("id")
+        if not user_id:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Invalid Authorization",
+            )
+        return DecodedToken(user_id=user_id)
+    except JWTError:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED, detail="IInvalid Authorization"
         )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.26.4
-transformers
+transformers==4.51
 alembic
 accelerate
 fastapi

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Annotated, List, Optional
 
-from crud.auth import get_current_user
+from crud.auth import get_current_user, get_current_user_websocket
 from crud.memo import (
     delete_memo_by_id,
     fetch_memo_by_id,
@@ -134,10 +134,14 @@ async def delete_memo(
 
 
 @router.websocket("/{memo_id}/body")
-async def websocket_memo_body(
-    websocket: WebSocket, db: DbDependency, user: UserDependency, memo_id: int
-):
+async def websocket_memo_body(websocket: WebSocket, db: DbDependency, memo_id: int):
     await websocket.accept()
+
+    try:
+        user = get_current_user_websocket(websocket)
+    except HTTPException:
+        await websocket.close(code=1008)
+        return
 
     memo = fetch_memo_by_id(db, user.user_id, memo_id)
 
@@ -167,7 +171,7 @@ async def websocket_memo_body(
 
     try:
         while True:
-            new_body = receive_valid_body(websocket=websocket)
+            new_body = await receive_valid_body(websocket=websocket)
             if new_body is None:
                 continue
 
@@ -223,13 +227,13 @@ async def receive_valid_body(  # WebSocketから受け取ったbodyの形式を�
     try:
         data = await websocket.receive_json()
     except ValueError:
-        await websocket.send_json({"status": "error", "detail": "Invalid JSON format"})
+        await websocket.send_json({"status": "error2", "detail": "Invalid JSON format"})
         return None
 
     new_body = data.get("body")
 
     if not isinstance(new_body, str):
-        await websocket.send_json({"status": "error", "detail": "Invalid JSON format"})
+        await websocket.send_json({"status": "error3", "detail": "Invalid JSON format"})
         return None
 
     return new_body

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -227,13 +227,13 @@ async def receive_valid_body(  # WebSocketから受け取ったbodyの形式を�
     try:
         data = await websocket.receive_json()
     except ValueError:
-        await websocket.send_json({"status": "error2", "detail": "Invalid JSON format"})
+        await websocket.send_json({"status": "error", "detail": "Invalid JSON format"})
         return None
 
     new_body = data.get("body")
 
     if not isinstance(new_body, str):
-        await websocket.send_json({"status": "error3", "detail": "Invalid JSON format"})
+        await websocket.send_json({"status": "error", "detail": "Invalid JSON format"})
         return None
 
     return new_body

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -1,9 +1,18 @@
+import asyncio
 from typing import Annotated, List, Optional
 
 from crud.auth import get_current_user
 from crud.memo import fetch_memos
 from database import get_db
-from fastapi import APIRouter, Depends, Header, Query, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    Query,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
 from schemas.auth import DecodedToken
 from schemas.memo import MemoPreviewResponse
 from sqlalchemy.orm import Session
@@ -28,3 +37,100 @@ async def read_root(
 ):
     memos = fetch_memos(db=db, user_id=user.user_id, search_word=keyword)
     return [MemoPreviewResponse.model_validate(m) for m in memos]
+
+
+@router.websocket("/{memo_id}/body")
+async def websocket_memo_body(
+    websocket: WebSocket, db: DbDependency, user: UserDependency, memo_id: int
+):
+    await websocket.accept()
+
+    memo = get_memo_by_id(db, user.user_id, memo_id)
+
+    if memo is None:
+        await websocket.send_json({"status": "error", "detail": "Memo not found"})
+        await websocket.close()
+        return
+
+    latest_body_ref = {"body": memo.body}
+    db_body_hash_ref = {"hash": hash(memo.body)}
+
+    lock = asyncio.Lock()
+
+    async def batch_update_loop():  # 1秒ごとにbodyの変更をDBに反映
+        while True:
+            await asyncio.sleep(1)
+            await update_if_changed(
+                db=db,
+                user_id=user.user_id,
+                memo_id=memo_id,
+                latest_body_ref=latest_body_ref,
+                db_body_hash_ref=db_body_hash_ref,
+                lock=lock,
+            )
+
+    batch_task = asyncio.create_task(batch_update_loop())
+
+    try:
+        while True:
+            new_body = receive_valid_body(websocket=websocket)
+            if new_body is None:
+                continue
+
+            async with lock:
+                if hash(new_body) == db_body_hash_ref["hash"]:
+                    continue
+                latest_body_ref["body"] = new_body
+
+            await websocket.send_json({"status": "success", "memo_id": memo_id})
+
+    except WebSocketDisconnect:  # 通信終了時に最終状態をDBに反映
+        batch_task.cancel()
+        try:
+            await batch_task
+        except asyncio.CancelledError:
+            pass
+
+        await update_if_changed(
+            db, user.user_id, memo_id, latest_body_ref, db_body_hash_ref, lock
+        )
+        await websocket.close()
+
+
+async def update_if_changed(  # 最新のbodyとDBのハッシュを比較し、変更があればDBを更新
+    db: DbDependency,
+    user_id: int,
+    memo_id: int,
+    latest_body_ref: dict,
+    db_body_hash_ref: dict,
+    lock: asyncio.Lock,
+):
+    async with lock:
+        latest_body_hash = hash(latest_body_ref["body"])
+        if latest_body_hash != db_body_hash_ref["hash"]:
+            await asyncio.to_thread(
+                update_memo_by_id,
+                db=db,
+                user_id=user_id,
+                memo_id=memo_id,
+                body=latest_body_ref["body"],
+            )
+            db_body_hash_ref["hash"] = latest_body_hash
+
+
+async def receive_valid_body(  # WebSocketから受け取ったbodyの形式を検証
+    websocket: WebSocket,
+):
+    try:
+        data = await websocket.receive_json()
+    except ValueError:
+        await websocket.send_json({"error": "Invalid JSON format"})
+        return None
+
+    new_body = data.get("body")
+
+    if not isinstance(new_body, str):
+        await websocket.send_json({"error": "Invalid payload"})
+        return None
+
+    return new_body

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -139,7 +139,7 @@ async def websocket_memo_body(
 ):
     await websocket.accept()
 
-    memo = get_memo_by_id(db, user.user_id, memo_id)
+    memo = fetch_memo_by_id(db, user.user_id, memo_id)
 
     if memo is None:
         await websocket.send_json({"status": "error", "detail": "Memo not found"})

--- a/backend/routers/memo.py
+++ b/backend/routers/memo.py
@@ -186,7 +186,12 @@ async def websocket_memo_body(
             pass
 
         await update_if_changed(
-            db, user.user_id, memo_id, latest_body_ref, db_body_hash_ref, lock
+            db=db,
+            user_id=user.user_id,
+            memo_id=memo_id,
+            latest_body_ref=latest_body_ref,
+            db_body_hash_ref=db_body_hash_ref,
+            lock=lock,
         )
         await websocket.close()
 
@@ -218,13 +223,13 @@ async def receive_valid_body(  # WebSocketから受け取ったbodyの形式を�
     try:
         data = await websocket.receive_json()
     except ValueError:
-        await websocket.send_json({"error": "Invalid JSON format"})
+        await websocket.send_json({"status": "error", "detail": "Invalid JSON format"})
         return None
 
     new_body = data.get("body")
 
     if not isinstance(new_body, str):
-        await websocket.send_json({"error": "Invalid payload"})
+        await websocket.send_json({"status": "error", "detail": "Invalid JSON format"})
         return None
 
     return new_body

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,11 +34,7 @@ def test_db():
 @pytest.fixture(scope="function")
 def client(test_db):
     def override_get_db():
-
-        try:
-            yield test_db
-        finally:
-            test_db.close()
+        yield test_db
 
     app.dependency_overrides[get_db] = override_get_db
     yield TestClient(app)

--- a/backend/tests/test_put_memo_by_id.py
+++ b/backend/tests/test_put_memo_by_id.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from models.memo import Memos
 from models.memotag import MemoTags
@@ -175,3 +177,126 @@ def test_failure_id_body(test_db, client):
         f"/memos/{memo_id}/tags", headers=headers, json={"tag_names": tag_names}
     )
     assert response.status_code == 404
+
+
+# 指定されたメモが正常に変更されるか(websocket)
+def test_normal_update_websocket(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    body = "成功"
+
+    with client.websocket_connect(
+        f"/memos/{memo_id}/body", headers=headers
+    ) as websocket:
+        websocket.send_json({"body": body})
+
+        response = websocket.receive_json()
+        assert response["status"] == "success"
+        assert response["memo_id"] == memo_id
+
+        asyncio.run(asyncio.sleep(1.2))
+
+        updated_memo = (
+            test_db.query(Memos).filter_by(id=memo_id, user_id=user_id).one_or_none()
+        )
+        assert updated_memo is not None
+        assert updated_memo.body == body
+
+
+# 存在しないメモを指定した場合に正常に通信が行われるかwebsocket)
+def test_empty_memo_websocket(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, EMPTY_MEMOS)
+
+    memo_id = 1
+    body = "失敗"
+
+    with client.websocket_connect(
+        f"/memos/{memo_id}/body", headers=headers
+    ) as websocket:
+        websocket.send_json({"body": body})
+
+        response = websocket.receive_json()
+        assert response["status"] == "error"
+
+
+# 異なるユーザのメモを指定した場合に正常に通信が行われるか(websocket)
+def test_failure_id_websocket(test_db, client):
+    user_id = "b"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, EMPTY_MEMOS)
+
+    memo_id = 1
+    body = "失敗"
+
+    with client.websocket_connect(
+        f"/memos/{memo_id}/body", headers=headers
+    ) as websocket:
+        websocket.send_json({"body": body})
+
+        response = websocket.receive_json()
+        assert response["status"] == "error"
+
+
+# 複数回更新したときに最後の更新が反映されるか(websocket)
+def test_multiple_updates_websocket(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    bodies = ["更新1", "更新２", "成功"]
+
+    with client.websocket_connect(
+        f"/memos/{memo_id}/body", headers=headers
+    ) as websocket:
+        websocket.send_json({"body": bodies[0]})
+        response1 = websocket.receive_json()
+        assert response1["status"] == "success"
+
+        websocket.send_json({"body": bodies[1]})
+        response2 = websocket.receive_json()
+        assert response2["status"] == "success"
+
+        websocket.send_json({"body": bodies[2]})
+        response3 = websocket.receive_json()
+        assert response3["status"] == "success"
+
+    asyncio.run(asyncio.sleep(1.2))
+
+    updated_memo = (
+        test_db.query(Memos).filter_by(id=memo_id, user_id=user_id).one_or_none()
+    )
+
+    assert updated_memo.body == bodies[2]
+
+
+# WebSocketの途中で接続が切れた場合に問題なく処理される
+def test_websocket_disconnect_midway(test_db, client):
+    user_id = "a"
+    headers = get_headers(user_id, client)
+    create_test_memos(test_db, SHORT_MEMOS)
+
+    memo_id = 1
+    body = "成功"
+
+    with client.websocket_connect(
+        f"/memos/{memo_id}/body", headers=headers
+    ) as websocket:
+        websocket.send_json({"body": body})
+        response = websocket.receive_json()
+        assert response["status"] == "success"
+
+        websocket.close()
+
+    asyncio.run(asyncio.sleep(1.2))
+
+    updated_memo = (
+        test_db.query(Memos).filter_by(id=memo_id, user_id=user_id).one_or_none()
+    )
+
+    assert updated_memo.body == body


### PR DESCRIPTION
relate: #26
close: #155

## 実施内容
- Websocket/memos/{memo_id}/bodyの実装

## 補足
- 処理が複雑になっているのですが，機能としては
  - DBへの更新は1秒おきで，変更がある場合のみ
    - 変更依頼はいつでも受け付けるが，反映タイミングが1秒おき
  - 通信切断時に最終状態をDBに反映

- 現在transformersが正常に動いていないそうですが，これはtransformers側の問題かと思われます．