### PR TITLE
feat: loaderとembedding関数の追加

### DIFF
--- a/backend/embedding/embedding.py
+++ b/backend/embedding/embedding.py
@@ -1,0 +1,22 @@
+import torch
+
+from .loader import load_embedding_model
+
+
+def get_embedding(text: str) -> list:
+    """
+    テキストをモデルで埋め込みベクトル化し、リストで返します。
+    """
+    model, tokenizer = load_embedding_model()
+    device = next(model.parameters()).device
+
+    with torch.no_grad():
+        # トークナイズしてデバイスへ転送
+        inputs = tokenizer([text], return_tensors="pt", padding=True, truncation=True)
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        # モデル推論とベクトル算出
+        outputs = model(**inputs)
+        vec = outputs.last_hidden_state.mean(dim=1)
+
+    # CPU上に移動し、NumPy配列をリスト形式で返す
+    return vec[0].cpu().numpy().tolist()

--- a/backend/embedding/loader.py
+++ b/backend/embedding/loader.py
@@ -1,0 +1,27 @@
+import torch
+from transformers import AutoModel, AutoTokenizer
+
+# モデルとトークナイザーを一度だけロードして再利用する
+_embedding_model = None
+_embedding_tokenizer = None
+_embedding_model_name = "BAAI/bge-m3"
+
+
+def load_embedding_model():
+    """
+    BAAI/bge-m3 モデルとトークナイザーをキャッシュして返す。
+    GPU があれば float16、なければ float32 でロードし、適切なデバイスに配置。
+    """
+    global _embedding_model, _embedding_tokenizer
+    # 未ロード時のみ初期化
+    if _embedding_model is None or _embedding_tokenizer is None:
+        # 利用可能なら GPU、なければ CPU
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        # トークナイザー読み込み
+        _embedding_tokenizer = AutoTokenizer.from_pretrained(_embedding_model_name)
+        # モデル読み込み (GPU 時は半精度で)
+        dtype = torch.float16 if device == "cuda" else torch.float32
+        _embedding_model = AutoModel.from_pretrained(
+            _embedding_model_name, torch_dtype=dtype
+        ).to(device)
+    return _embedding_model, _embedding_tokenizer

--- a/backend/llm/utils/generator.py
+++ b/backend/llm/utils/generator.py
@@ -1,8 +1,8 @@
-from llm.utils.loader import load_model
+from llm.utils.loader import load_llm_model
 
 
 def generate_text(prompt: str, enable_thinking: bool, max_new_tokens: int) -> str:
-    model, tokenizer = load_model()
+    model, tokenizer = load_llm_model()
 
     # JSON形式の出力を強制するプロンプト設計
     json_prompt = f"""

--- a/backend/llm/utils/loader.py
+++ b/backend/llm/utils/loader.py
@@ -5,7 +5,7 @@ _tokenizer = None
 _model_name = "Qwen/Qwen3-4B"
 
 
-def load_model():
+def load_llm_model():
     """
     モデルとトークナイザーを一度だけロードしてキャッシュし、返す。
     """

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,16 @@
 from contextlib import asynccontextmanager
 
+from embedding.loader import load_embedding_model
 from fastapi import FastAPI
-from llm.utils.loader import load_model
+from llm.utils.loader import load_llm_model
 from routers import auth, memo, memo_websocket, tag
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # サーバ起動時に一度だけモデルをロード
-    load_model()
+    load_llm_model()
+    load_embedding_model()
     yield
 
 


### PR DESCRIPTION
close #193
relate #101

- embeddingモデルのloaderとテキストをベクトルにして返すembedding関数を作成しました
- embeddingモデルは商用利用可能で8192トークンまで入力可能な[BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3)を使用しています、埋め込み次元は1024次元です
- embedding関数はメモの埋め込み(title + body)とタグの埋め込みに使用する想定です
- 関数が動作することを確認済みです
- embeddingのloader関数と見分けがつくように、llmのloader関数をリネームしました(この点で別のPRとのコンフリクトが発生する気がしています、失念です)

sprint1が完了していない段階なので、一応マージ先をsprint1にしておきます
