### PR TITLE
feat: MemoCardにお気に入り表示

### DIFF
--- a/frontend/lib/widgets/memo_card.dart
+++ b/frontend/lib/widgets/memo_card.dart
@@ -5,10 +5,16 @@ import 'package:frontend/models/memo_preview.dart';
 import 'package:frontend/router.gr.dart';
 
 class MemoCard extends HookWidget {
-  const MemoCard({required this.memoPreview, super.key, this.showBody = true});
+  const MemoCard({
+    required this.memoPreview,
+    super.key,
+    this.showBody = true,
+    this.showFavoriteButton = true,
+  });
 
   final MemoPreview memoPreview;
   final bool showBody;
+  final bool showFavoriteButton;
 
   @override
   Widget build(BuildContext context) {
@@ -19,30 +25,53 @@ class MemoCard extends HookWidget {
       context.router.push(const MemoDetailsRoute());
     }
 
+    // TODO(Rozelin-dc): MemoPreviewのフラグを見るようにする
+    final isFavorite = useState(false);
+
     return GestureDetector(
       onTap: onTap,
       child: Card(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
+          child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
-            spacing: 4,
+            spacing: 8,
             children: [
-              Text(
-                memoPreview.title,
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 4,
+                  children: [
+                    Text(
+                      memoPreview.title,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                    ),
+                    if (showBody)
+                      Text(
+                        memoPreview.body,
+                        style: theme.textTheme.bodyMedium,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 3,
+                      ),
+                  ],
                 ),
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
               ),
-              if (showBody)
-                Text(
-                  memoPreview.body,
-                  style: theme.textTheme.bodyMedium,
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 3,
+              if (showFavoriteButton)
+                IconButton(
+                  icon: Icon(
+                    isFavorite.value
+                        ? Icons.favorite
+                        : Icons.favorite_border_outlined,
+                  ),
+                  onPressed: () {
+                    isFavorite.value = !isFavorite.value;
+                    // TODO(Rozelin-dc): API処理
+                  },
                 ),
             ],
           ),


### PR DESCRIPTION
close #200 
relate #178 

## 概要
- メモカードにお気に入り状態を表示できるようにしました
- アイコンタップでお気に入り状態を切り替えられますが、APIリクエスト処理はやっていません

![image](https://github.com/user-attachments/assets/86e745cc-f312-46e4-a3f7-5a0ae90b29fe)
