### PR TITLE
feat: メモ詳細画面でお気に入り状態が切り替えられるように

### DIFF
--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -36,6 +36,8 @@ class MemoDetailsPage extends HookConsumerWidget {
 
     final memo = memoAsyncValue.requireValue;
     final tags = ref.watch(memoTagNamesProvider);
+    // TODO(Rozelin-dc): memoのフラグを参照するように
+    final isFavorite = useState(false);
 
     final currentTab = useState(MemoDetailsTab.body);
     final tabController = useTabController(
@@ -60,7 +62,22 @@ class MemoDetailsPage extends HookConsumerWidget {
     final showFab = !isEditingMode && currentTab.value == MemoDetailsTab.body;
 
     return Scaffold(
-      appBar: AppBar(title: MemoTitleMenu(memo: memo)),
+      appBar: AppBar(
+        title: MemoTitleMenu(memo: memo),
+        actions: [
+          IconButton(
+            icon: Icon(
+              isFavorite.value
+                  ? Icons.favorite
+                  : Icons.favorite_border_outlined,
+            ),
+            onPressed: () {
+              isFavorite.value = !isFavorite.value;
+              // TODO(Rozelin-dc): API処理
+            },
+          ),
+        ],
+      ),
       floatingActionButton:
           showFab
               ? FloatingActionButton(


### PR DESCRIPTION
close #201 
relate #178 

## 概要
- メモ詳細画面のAppBar右側でお気に入り状態を切り替えられるようにしました
- API処理はまだです

debugの帯に被って見えにくいです 🙇 
![image](https://github.com/user-attachments/assets/996450ba-4098-4215-a657-cb36351fdc3b)
