### PR TITLE
feat: ホーム画面からメモを追加するAPIを接続

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:frontend/providers/router_provider.dart';
 import 'package:frontend/theme.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:loader_overlay/loader_overlay.dart';
 
 void main() {
   // 縦画面に固定
@@ -21,15 +22,17 @@ class MyApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(appRouterProvider);
 
-    return MaterialApp.router(
-      routerConfig: router.config(),
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        FlutterQuillLocalizations.delegate,
-      ],
-      theme: buildThemeData(Brightness.light),
+    return GlobalLoaderOverlay(
+      child: MaterialApp.router(
+        routerConfig: router.config(),
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          FlutterQuillLocalizations.delegate,
+        ],
+        theme: buildThemeData(Brightness.light),
+      ),
     );
   }
 }

--- a/frontend/lib/pages/errors/memo_error_with_refresh_page.dart
+++ b/frontend/lib/pages/errors/memo_error_with_refresh_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/models/memo.dart';
+import 'package:frontend/providers/memo_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class MemoErrorWithRefreshPage extends ConsumerWidget {
+  const MemoErrorWithRefreshPage({required this.memoId, super.key});
+
+  final MemoId memoId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('エラー')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('エラーが発生しました。やり直してください'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                ref.invalidate(memoProvider(memoId));
+              },
+              child: const Text('再読み込み'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/pages/errors/memo_not_found_page.dart
+++ b/frontend/lib/pages/errors/memo_not_found_page.dart
@@ -1,0 +1,26 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+class MemoNotFoundPage extends StatelessWidget {
+  const MemoNotFoundPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('エラー')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('メモが見つかりません'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: context.router.pop,
+              child: const Text('戻る'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/pages/home_page.dart
+++ b/frontend/lib/pages/home_page.dart
@@ -22,12 +22,24 @@ class HomePage extends HookConsumerWidget {
     final focusNode = useFocusNode();
 
     Future<void> submit(String raw) async {
-      textController.clear();
       context.loaderOverlay.show();
-      final memo = await ref.read(memoRepositoryProvider).addMemo(raw);
-      if (context.mounted) {
-        context.loaderOverlay.hide();
-        unawaited(context.router.push(MemoDetailsRoute(memoId: memo.id)));
+      try {
+        final memo = await ref.read(memoRepositoryProvider).addMemo(raw);
+        textController.clear();
+        if (context.mounted) {
+          unawaited(context.router.push(MemoDetailsRoute(memoId: memo.id)));
+        }
+      } on Exception catch (e) {
+        debugPrint('Error adding memo: $e');
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('メモの追加に失敗しました。やり直してください')),
+          );
+        }
+      } finally {
+        if (context.mounted) {
+          context.loaderOverlay.hide();
+        }
       }
     }
 

--- a/frontend/lib/pages/home_page.dart
+++ b/frontend/lib/pages/home_page.dart
@@ -1,24 +1,34 @@
+import 'dart:async';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:frontend/providers/repository_provider.dart';
+import 'package:frontend/router.gr.dart';
 import 'package:frontend/widgets/destination_navigation_drawer.dart';
 import 'package:frontend/widgets/memo_text_field.dart';
 import 'package:frontend/widgets/record_button.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:loader_overlay/loader_overlay.dart';
 
 @RoutePage()
-class HomePage extends HookWidget {
+class HomePage extends HookConsumerWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final isKeyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 16;
     final textController = useTextEditingController();
     final focusNode = useFocusNode();
 
-    void submit(String raw) {
-      // TODO(tyPhoon-collab): メモを保存する処理を実装
-      debugPrint('Submitted: $raw');
+    Future<void> submit(String raw) async {
       textController.clear();
+      context.loaderOverlay.show();
+      final memo = await ref.read(memoRepositoryProvider).addMemo(raw);
+      if (context.mounted) {
+        context.loaderOverlay.hide();
+        unawaited(context.router.push(MemoDetailsRoute(memoId: memo.id)));
+      }
     }
 
     return Scaffold(

--- a/frontend/lib/pages/home_page.dart
+++ b/frontend/lib/pages/home_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:frontend/providers/repository_provider.dart';
 import 'package:frontend/router.gr.dart';
+import 'package:frontend/types/extensions/snack_bar.dart';
 import 'package:frontend/widgets/destination_navigation_drawer.dart';
 import 'package:frontend/widgets/memo_text_field.dart';
 import 'package:frontend/widgets/record_button.dart';
@@ -32,9 +33,9 @@ class HomePage extends HookConsumerWidget {
       } on Exception catch (e) {
         debugPrint('Error adding memo: $e');
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('メモの追加に失敗しました。やり直してください')),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showErrorSnackBar(message: 'メモの追加に失敗しました。やり直してください');
         }
       } finally {
         if (context.mounted) {

--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -21,17 +21,21 @@ enum MemoDetailsTab {
 
 @RoutePage()
 class MemoDetailsPage extends HookConsumerWidget {
-  const MemoDetailsPage({super.key});
+  const MemoDetailsPage({required this.memoId, super.key});
+
+  final MemoId memoId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final memoAsyncValue = ref.watch(memoProvider(const MemoId(1)));
+    final memoAsyncValue = ref.watch(memoProvider(memoId));
 
     if (memoAsyncValue.isLoading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
     if (memoAsyncValue.hasError) {
-      return const Scaffold(body: Center(child: Text('メモの取得に失敗しました')));
+      return Scaffold(
+        body: Center(child: Text(memoAsyncValue.error.toString())),
+      );
     }
 
     final memo = memoAsyncValue.requireValue;
@@ -42,6 +46,10 @@ class MemoDetailsPage extends HookConsumerWidget {
       initialLength: MemoDetailsTab.values.length,
     );
 
+    void updateCurrentTab() {
+      currentTab.value = MemoDetailsTab.values[tabController.index];
+    }
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ref.read(memoTagNamesProvider.notifier).setTags(memo.tags);
@@ -50,10 +58,10 @@ class MemoDetailsPage extends HookConsumerWidget {
     }, [memo]);
 
     useEffect(() {
-      tabController.addListener(() {
-        currentTab.value = MemoDetailsTab.values[tabController.index];
-      });
-      return tabController.dispose;
+      tabController.addListener(updateCurrentTab);
+      return () {
+        tabController.removeListener(updateCurrentTab);
+      };
     }, [tabController]);
 
     final isEditingMode = ref.watch(isEditingModeProvider);

--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -2,8 +2,11 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:frontend/models/memo.dart';
+import 'package:frontend/pages/errors/memo_error_with_refresh_page.dart';
+import 'package:frontend/pages/errors/memo_not_found_page.dart';
 import 'package:frontend/providers/memo_edit_provider.dart';
 import 'package:frontend/providers/memo_provider.dart';
+import 'package:frontend/repositories/memo_repository/memo_repository.dart';
 import 'package:frontend/widgets/dialogs/delete_dialog.dart';
 import 'package:frontend/widgets/dialogs/input_dialog.dart';
 import 'package:frontend/widgets/memo_details/memo_body_view.dart';
@@ -27,18 +30,21 @@ class MemoDetailsPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final memoAsyncValue = ref.watch(memoProvider(memoId));
+    final memoValue = ref.watch(memoProvider(memoId));
 
-    if (memoAsyncValue.isLoading) {
+    if (memoValue.isLoading) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    if (memoAsyncValue.hasError) {
-      return Scaffold(
-        body: Center(child: Text(memoAsyncValue.error.toString())),
-      );
+    if (memoValue.hasError) {
+      final error = memoValue.error;
+      debugPrint('memoAsyncValue error: $error');
+      return switch (error) {
+        final MemoNotFoundException _ => const MemoNotFoundPage(),
+        _ => MemoErrorWithRefreshPage(memoId: memoId),
+      };
     }
 
-    final memo = memoAsyncValue.requireValue;
+    final memo = memoValue.requireValue;
     final tags = ref.watch(memoTagNamesProvider);
 
     final currentTab = useState(MemoDetailsTab.body);

--- a/frontend/lib/providers/memo_provider.dart
+++ b/frontend/lib/providers/memo_provider.dart
@@ -1,5 +1,5 @@
 import 'package:frontend/models/memo.dart';
-import 'package:frontend/models/tag.dart';
+import 'package:frontend/providers/repository_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -7,36 +7,5 @@ part 'memo_provider.g.dart';
 
 @riverpod
 Future<Memo> memo(Ref ref, MemoId id) async {
-  return Memo(
-    id: const MemoId(1),
-    title: '仮タイトル',
-    body: '''
-## プログラミング学習の始め方
-
-プログラミング学習を始めるためのステップをいくつかご紹介します。
-
-1.  **目標設定:** なぜプログラミングを学びたいのか、具体的な目標を決めましょう。（例: Webサイト作成、データ分析、ゲーム開発など）
-2.  **言語選択:** 目標に合ったプログラミング言語を選びます。初心者にはPythonなどがおすすめです。
-3.  **学習リソース:** オンラインチュートリアル、公式ドキュメント、書籍などを活用します。
-4.  **実践:** 小さなプログラムを実際に書いて、動かしてみることが重要です。
-
-### Pythonの簡単なコード例
-
-```python
-# Hello Worldを表示するコード
-print("Hello, World!")
-```
-
-このコードを実行すると、「Hello, World!」と出力されます。
-
------
-
-ご不明な点がございましたら、お気軽にご質問ください。''',
-    raw: 'あいうえお',
-    tags: const [
-      Tag(id: TagId(1), name: '仮タグ1'),
-      Tag(id: TagId(2), name: '仮タグ2'),
-    ],
-    createdAt: DateTime.now(),
-  );
+  return ref.watch(memoRepositoryProvider).getMemoById(id);
 }

--- a/frontend/lib/providers/memo_provider.g.dart
+++ b/frontend/lib/providers/memo_provider.g.dart
@@ -6,7 +6,7 @@ part of 'memo_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$memoHash() => r'e071d5a2973c38133d03fa9badaa9b605b796aea';
+String _$memoHash() => r'0d0bc51cfb7d6eec9899d681ad516f2e26b061f2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/frontend/lib/providers/repository_provider.dart
+++ b/frontend/lib/providers/repository_provider.dart
@@ -1,6 +1,7 @@
+import 'package:frontend/providers/service_provider.dart';
 import 'package:frontend/repositories/auth_repository/auth_repository.dart';
 import 'package:frontend/repositories/auth_repository/shared_preferences_auth_repository.dart';
-import 'package:frontend/repositories/memo_repository/in_memory_memo_repository.dart';
+import 'package:frontend/repositories/memo_repository/api_client_memo_repository.dart';
 import 'package:frontend/repositories/memo_repository/memo_repository.dart';
 import 'package:frontend/repositories/user_id_repository/device_user_id_repository.dart';
 import 'package:frontend/repositories/user_id_repository/user_id_repository.dart';
@@ -11,8 +12,8 @@ part 'repository_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 MemoRepository memoRepository(Ref ref) {
-  return InMemoryMemoRepository(); // 本番環境では実装を差し替える
-  // return ApiClientMemoRepository(ref.watch(memoApiClientProvider));
+  // return InMemoryMemoRepository(); // サーバなしでの検証時に使用
+  return ApiClientMemoRepository(ref.watch(memoApiClientProvider));
 }
 
 @Riverpod(keepAlive: true)

--- a/frontend/lib/providers/repository_provider.g.dart
+++ b/frontend/lib/providers/repository_provider.g.dart
@@ -6,7 +6,7 @@ part of 'repository_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$memoRepositoryHash() => r'a110590bdca376ee0787315e5b2cc8aa243e8152';
+String _$memoRepositoryHash() => r'574f7879c7ae14b283e4094fb285da15f275a97a';
 
 /// See also [memoRepository].
 @ProviderFor(memoRepository)

--- a/frontend/lib/router.gr.dart
+++ b/frontend/lib/router.gr.dart
@@ -10,6 +10,8 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:auto_route/auto_route.dart' as _i4;
+import 'package:flutter/material.dart' as _i6;
+import 'package:frontend/models/memo.dart' as _i5;
 import 'package:frontend/pages/home_page.dart' as _i1;
 import 'package:frontend/pages/memo_details_page.dart' as _i2;
 import 'package:frontend/pages/memo_list_view_page.dart' as _i3;
@@ -32,18 +34,39 @@ class HomeRoute extends _i4.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i2.MemoDetailsPage]
-class MemoDetailsRoute extends _i4.PageRouteInfo<void> {
-  const MemoDetailsRoute({List<_i4.PageRouteInfo>? children})
-    : super(MemoDetailsRoute.name, initialChildren: children);
+class MemoDetailsRoute extends _i4.PageRouteInfo<MemoDetailsRouteArgs> {
+  MemoDetailsRoute({
+    required _i5.MemoId memoId,
+    _i6.Key? key,
+    List<_i4.PageRouteInfo>? children,
+  }) : super(
+         MemoDetailsRoute.name,
+         args: MemoDetailsRouteArgs(memoId: memoId, key: key),
+         initialChildren: children,
+       );
 
   static const String name = 'MemoDetailsRoute';
 
   static _i4.PageInfo page = _i4.PageInfo(
     name,
     builder: (data) {
-      return const _i2.MemoDetailsPage();
+      final args = data.argsAs<MemoDetailsRouteArgs>();
+      return _i2.MemoDetailsPage(memoId: args.memoId, key: args.key);
     },
   );
+}
+
+class MemoDetailsRouteArgs {
+  const MemoDetailsRouteArgs({required this.memoId, this.key});
+
+  final _i5.MemoId memoId;
+
+  final _i6.Key? key;
+
+  @override
+  String toString() {
+    return 'MemoDetailsRouteArgs{memoId: $memoId, key: $key}';
+  }
 }
 
 /// generated route for

--- a/frontend/lib/types/extensions/snack_bar.dart
+++ b/frontend/lib/types/extensions/snack_bar.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+extension ScaffoldMessengerStateExtension on ScaffoldMessengerState {
+  void showErrorSnackBar({required String message}) {
+    final colorScheme = Theme.of(context).colorScheme;
+    showSnackBar(
+      SnackBar(
+        content: Text(message, style: TextStyle(color: colorScheme.onError)),
+        backgroundColor: colorScheme.error,
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/memo_card.dart
+++ b/frontend/lib/widgets/memo_card.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/memo_preview.dart';
 import 'package:frontend/router.gr.dart';
 
@@ -15,8 +16,7 @@ class MemoCard extends HookWidget {
     final theme = Theme.of(context);
 
     void onTap() {
-      // TODO(anyone): memoPreview.idを渡す, https://github.com/HACK-U-2025-2/HACKU/issues/22
-      context.router.push(const MemoDetailsRoute());
+      context.router.push(MemoDetailsRoute(memoId: const MemoId(1)));
     }
 
     return GestureDetector(

--- a/frontend/lib/widgets/memo_card.dart
+++ b/frontend/lib/widgets/memo_card.dart
@@ -1,7 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/memo_preview.dart';
 import 'package:frontend/router.gr.dart';
 
@@ -16,7 +15,7 @@ class MemoCard extends HookWidget {
     final theme = Theme.of(context);
 
     void onTap() {
-      context.router.push(MemoDetailsRoute(memoId: const MemoId(1)));
+      context.router.push(MemoDetailsRoute(memoId: memoPreview.id));
     }
 
     return GestureDetector(

--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -51,7 +51,7 @@ class MemoTitleMenu extends StatelessWidget {
               spacing: 8,
               children: [
                 const SizedBox(width: 16), // バランスを取るためのスペース
-                child!,
+                Flexible(child: child!),
                 const Icon(Icons.arrow_drop_down),
               ],
             ),

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
+  back_button_interceptor:
+    dependency: transitive
+    description:
+      name: back_button_interceptor
+      sha256: b85977faabf4aeb95164b3b8bf81784bed4c54ea1aef90a036ab6927ecf80c5a
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -653,6 +661,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  loader_overlay:
+    dependency: "direct main"
+    description:
+      name: loader_overlay
+      sha256: "285c9ccab9a42a392ba948bd0b14376fd0ee9ddd7b63e3018bcd54460fd3e021"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   logging:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   shared_preferences: ^2.5.3
   device_info_plus: ^11.4.0
   universal_platform: ^1.1.0
+  loader_overlay: ^5.0.0
 
 dev_dependencies:
   auto_route_generator: ^10.0.1


### PR DESCRIPTION
close #124 
relate #19

API接続（リポジトリクラス経由）

HomePageに追加のAPI、memoProviderに取得のAPI

## 備考
- エラーハンドリングをしている
- [loader_overlay | Flutter package](https://pub.dev/packages/loader_overlay)を導入
  - サーバのレスポンス待ちの時に、ローディングインジケーターを表示するため 
  - GlobalLoaderOverlayはこのライブラリのWidget
  - `context.loaderOverlay.show()`と`context.loaderOverlay.hide()`で表示切り替え
- MemoDetailsPageにmemoIdの引数追加
  - 追加後、画面遷移する仕様にしたため、memoIdを渡して、詳細画面に行けるようにしている
  - 一部、関連する修正の差分も含めている