### PR TITLE
feat: メモのタイトルと本文を更新する機能のAPI接続と関連する実装

### DIFF
--- a/frontend/lib/models/memo.dart
+++ b/frontend/lib/models/memo.dart
@@ -20,6 +20,10 @@ sealed class Memo with _$Memo {
   }) = _Memo;
 
   factory Memo.fromJson(Map<String, dynamic> json) => _$MemoFromJson(json);
+
+  const Memo._();
+
+  List<String> get tagNames => tags.map((tag) => tag.name).toList();
 }
 
 final class MemoIdJsonConverter implements JsonConverter<MemoId, int> {

--- a/frontend/lib/models/memo.freezed.dart
+++ b/frontend/lib/models/memo.freezed.dart
@@ -85,8 +85,8 @@ as DateTime?,
 /// @nodoc
 
 @JsonSerializable(fieldRename: FieldRename.snake)
-class _Memo implements Memo {
-  const _Memo({@MemoIdJsonConverter() required this.id, required this.title, required this.body, required this.raw, required this.createdAt, final  List<Tag> tags = const [], this.updatedAt}): _tags = tags;
+class _Memo extends Memo {
+  const _Memo({@MemoIdJsonConverter() required this.id, required this.title, required this.body, required this.raw, required this.createdAt, final  List<Tag> tags = const [], this.updatedAt}): _tags = tags,super._();
   factory _Memo.fromJson(Map<String, dynamic> json) => _$MemoFromJson(json);
 
 @override@MemoIdJsonConverter() final  MemoId id;

--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -32,7 +32,7 @@ class MemoDetailsPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final memoValue = ref.watch(memoProvider(memoId));
 
-    if (memoValue.isLoading) {
+    if (memoValue.isLoading && !memoValue.hasValue) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
     if (memoValue.hasError) {

--- a/frontend/lib/providers/memo_edit_provider.dart
+++ b/frontend/lib/providers/memo_edit_provider.dart
@@ -28,15 +28,9 @@ class MemoTagNames extends _$MemoTagNames {
 
   void addTag(String tag) {
     state = [...state, tag];
-    _update();
   }
 
   void removeTag(String tag) {
     state = state.where((t) => t != tag).toList();
-    _update();
-  }
-
-  void _update() {
-    // TODO(tyPhoon-collab): タグを削除する処理を実装する
   }
 }

--- a/frontend/lib/providers/memo_edit_provider.g.dart
+++ b/frontend/lib/providers/memo_edit_provider.g.dart
@@ -23,7 +23,7 @@ final isEditingModeProvider =
     );
 
 typedef _$IsEditingMode = AutoDisposeNotifier<bool>;
-String _$memoTagNamesHash() => r'17635115a62ceb909164a2c1e9a0aae23a16cf88';
+String _$memoTagNamesHash() => r'83280f9efe54965da9cbb119f81aa9bb6982039b';
 
 /// See also [MemoTagNames].
 @ProviderFor(MemoTagNames)

--- a/frontend/lib/widgets/memo_details/memo_body_view.dart
+++ b/frontend/lib/widgets/memo_details/memo_body_view.dart
@@ -1,10 +1,16 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:frontend/models/memo.dart';
 import 'package:frontend/providers/memo_edit_provider.dart';
+import 'package:frontend/providers/memo_provider.dart';
+import 'package:frontend/providers/repository_provider.dart';
+import 'package:frontend/repositories/memo_repository/memo_repository.dart';
+import 'package:frontend/types/extensions/snack_bar.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:loader_overlay/loader_overlay.dart';
 
 class MemoBodyView extends HookConsumerWidget {
   const MemoBodyView({required this.memo, super.key});
@@ -51,7 +57,7 @@ class _EditView extends HookWidget {
           Expanded(child: QuillEditor.basic(controller: controller)),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),
-            child: _EditToolBar(controller: controller),
+            child: _EditToolBar(memo: memo, controller: controller),
           ),
         ],
       ),
@@ -60,12 +66,65 @@ class _EditView extends HookWidget {
 }
 
 class _EditToolBar extends ConsumerWidget {
-  const _EditToolBar({required this.controller});
+  const _EditToolBar({required this.memo, required this.controller});
 
+  final Memo memo;
   final QuillController controller;
+
+  MemoId get id => memo.id;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    /// BodyとTagsを更新する
+    Future<void> update() async {
+      final repo = ref.read(memoRepositoryProvider);
+      final newBody = controller.document.toPlainText();
+      final newTags = ref.read(memoTagNamesProvider);
+
+      final wasBodyChanged = newBody.trim() != memo.body.trim();
+      final wasTagsChanged = !listEquals(newTags, memo.tagNames);
+      final wasChanged = wasBodyChanged || wasTagsChanged;
+
+      context.loaderOverlay.show();
+      try {
+        // 本文が変更されている場合のみ更新
+        if (wasBodyChanged) {
+          await repo.updateMemoBody(id, newBody);
+        }
+        // タグが変更されている場合のみ更新
+        if (wasTagsChanged) {
+          await repo.updateMemoTags(id, newTags);
+        }
+
+        if (context.mounted && wasChanged) {
+          // データを再取得
+          ref.invalidate(memoProvider(id));
+
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('メモを更新しました。')));
+        }
+
+        // 編集モードを終了
+        ref.read(isEditingModeProvider.notifier).toggle();
+      } on Exception catch (e) {
+        debugPrint('Error updating memo body: $e');
+
+        if (context.mounted) {
+          final message = switch (e) {
+            final MemoNotFoundException _ => 'メモが見つかりません。',
+            final MemoValidationException _ => '有効な内容ではありません。メモの内容を確認してください。',
+            _ => 'メモの更新に失敗しました。やり直してください。',
+          };
+          ScaffoldMessenger.of(context).showErrorSnackBar(message: message);
+        }
+      } finally {
+        if (context.mounted) {
+          context.loaderOverlay.hide();
+        }
+      }
+    }
+
     return ListenableBuilder(
       listenable: controller,
       builder:
@@ -91,12 +150,7 @@ class _EditToolBar extends ConsumerWidget {
               ),
               IconButton.filled(
                 icon: const Icon(Icons.check),
-                onPressed: () {
-                  ref.read(isEditingModeProvider.notifier).toggle();
-                  // TODO(tyPhoon-collab): 保存処理を実装する
-                  final newBody = controller.document.toPlainText();
-                  debugPrint('New Body: $newBody');
-                },
+                onPressed: update,
               ),
             ],
           ),

--- a/frontend/lib/widgets/memo_details/memo_body_view.dart
+++ b/frontend/lib/widgets/memo_details/memo_body_view.dart
@@ -85,6 +85,8 @@ class _EditToolBar extends ConsumerWidget {
       final wasTagsChanged = !listEquals(newTags, memo.tagNames);
       final wasChanged = wasBodyChanged || wasTagsChanged;
 
+      if (!wasChanged) return;
+
       context.loaderOverlay.show();
       try {
         // 本文が変更されている場合のみ更新
@@ -96,7 +98,7 @@ class _EditToolBar extends ConsumerWidget {
           await repo.updateMemoTags(id, newTags);
         }
 
-        if (context.mounted && wasChanged) {
+        if (context.mounted) {
           // データを再取得
           ref.invalidate(memoProvider(id));
 
@@ -104,9 +106,6 @@ class _EditToolBar extends ConsumerWidget {
             context,
           ).showSnackBar(const SnackBar(content: Text('メモを更新しました。')));
         }
-
-        // 編集モードを終了
-        ref.read(isEditingModeProvider.notifier).toggle();
       } on Exception catch (e) {
         debugPrint('Error updating memo body: $e');
 
@@ -150,7 +149,10 @@ class _EditToolBar extends ConsumerWidget {
               ),
               IconButton.filled(
                 icon: const Icon(Icons.check),
-                onPressed: update,
+                onPressed: () async {
+                  await update();
+                  ref.read(isEditingModeProvider.notifier).toggle();
+                },
               ),
             ],
           ),

--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -1,22 +1,56 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/models/memo.dart';
+import 'package:frontend/providers/memo_provider.dart';
+import 'package:frontend/providers/repository_provider.dart';
+import 'package:frontend/repositories/memo_repository/memo_repository.dart';
+import 'package:frontend/types/extensions/snack_bar.dart';
 import 'package:frontend/widgets/dialogs/delete_dialog.dart';
 import 'package:frontend/widgets/dialogs/input_dialog.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:loader_overlay/loader_overlay.dart';
 
-class MemoTitleMenu extends StatelessWidget {
+class MemoTitleMenu extends ConsumerWidget {
   const MemoTitleMenu({required this.memo, super.key});
 
   final Memo memo;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     Future<void> updateTitle() async {
       final newTitle = await showDialog<String>(
         context: context,
         builder: (context) => MemoTitleInputDialog(initialValue: memo.title),
       );
-      if (newTitle != null) {
-        // TODO(tyPhoon-collab): メモタイトル更新の処理を実装する
+      if (newTitle != null && context.mounted) {
+        context.loaderOverlay.show();
+        try {
+          await ref
+              .read(memoRepositoryProvider)
+              .updateMemoTitle(memo.id, newTitle);
+          if (context.mounted) {
+            // データを再取得
+            ref.invalidate(memoProvider(memo.id));
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(const SnackBar(content: Text('タイトルを更新しました')));
+          }
+        } on Exception catch (e) {
+          debugPrint('Error updating memo title: $e');
+
+          if (context.mounted) {
+            final message = switch (e) {
+              final MemoNotFoundException _ => 'メモが見つかりませんでした。',
+              final MemoValidationException _ =>
+                '有効なタイトルではありません。メモのタイトルを確認してください。',
+              _ => 'タイトルの更新に失敗しました。やり直してください。',
+            };
+            ScaffoldMessenger.of(context).showErrorSnackBar(message: message);
+          }
+        } finally {
+          if (context.mounted) {
+            context.loaderOverlay.hide();
+          }
+        }
       }
     }
 
@@ -25,8 +59,31 @@ class MemoTitleMenu extends StatelessWidget {
         context: context,
         builder: (context) => const MemoDeleteDialog(),
       );
-      if (isDeletionSelected ?? false) {
-        // TODO(tyPhoon-collab): メモ削除の処理を実装する
+      if ((isDeletionSelected ?? false) && context.mounted) {
+        context.loaderOverlay.show();
+        try {
+          await ref.read(memoRepositoryProvider).deleteMemo(memo.id);
+          if (context.mounted) {
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(const SnackBar(content: Text('メモを削除しました')));
+            Navigator.of(context).pop();
+          }
+        } on Exception catch (e) {
+          debugPrint('Error deleting memo: $e');
+
+          if (context.mounted) {
+            final message = switch (e) {
+              final MemoNotFoundException _ => 'メモが見つかりませんでした。',
+              _ => 'メモの削除に失敗しました。やり直してください。',
+            };
+            ScaffoldMessenger.of(context).showErrorSnackBar(message: message);
+          }
+        } finally {
+          if (context.mounted) {
+            context.loaderOverlay.hide();
+          }
+        }
       }
     }
 


### PR DESCRIPTION
close #125 
relate #22 

## 相談したいこと
- タグの編集の更新をチェックを押したときにしている
  - チェックボタンを押したときに反映するのが直感的と感じた
  - Websocketに対応した場合は、チェックボタンをなくし、随時更新するという流れが良さそう。どうでしょうか？

- すべてのAPI呼び出し時にローディングの表示をしている
  - すべてに対しては不要かも
  - 画面がちらつくので、update系のAPIの場合はローディングの表示を無くすとか。どうでしょうか？