### PR TITLE
fix: メモ詳細画面のタイトルのスタイルを修正

### DIFF
--- a/frontend/lib/widgets/memo_details/memo_title_menu.dart
+++ b/frontend/lib/widgets/memo_details/memo_title_menu.dart
@@ -50,7 +50,6 @@ class MemoTitleMenu extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               spacing: 8,
               children: [
-                const SizedBox(width: 16), // バランスを取るためのスペース
                 Flexible(child: child!),
                 const Icon(Icons.arrow_drop_down),
               ],
@@ -60,7 +59,9 @@ class MemoTitleMenu extends StatelessWidget {
       },
       child: Text(
         memo.title,
-        style: const TextStyle(overflow: TextOverflow.fade),
+        style: Theme.of(
+          context,
+        ).textTheme.titleMedium?.copyWith(overflow: TextOverflow.ellipsis),
       ),
     );
   }


### PR DESCRIPTION
close #213 
relate #209 

AppBarのTextの大きさを変えてます
<img width="408" alt="image" src="https://github.com/user-attachments/assets/d7e94057-4966-4dfe-8780-4aaa77ae856a" />
