### PR TITLE
feat: メモ一覧ページのAPI接続

### DIFF
--- a/frontend/lib/hooks/use_create_memo.dart
+++ b/frontend/lib/hooks/use_create_memo.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:frontend/providers/repository_provider.dart';
+import 'package:frontend/router.gr.dart';
+import 'package:frontend/types/extensions/snack_bar.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:loader_overlay/loader_overlay.dart';
+
+Future<void> Function(String) useCreateMemo({
+  required BuildContext context,
+  required WidgetRef ref,
+  void Function()? afterCreate,
+}) {
+  return (String raw) async {
+    context.loaderOverlay.show();
+    try {
+      final memo = await ref.read(memoRepositoryProvider).addMemo(raw);
+      if (afterCreate != null) {
+        afterCreate();
+      }
+      if (context.mounted) {
+        unawaited(context.router.push(MemoDetailsRoute(memoId: memo.id)));
+      }
+    } on Exception catch (e) {
+      debugPrint('Error adding memo: $e');
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showErrorSnackBar(message: 'メモの追加に失敗しました。やり直してください');
+      }
+    } finally {
+      if (context.mounted) {
+        context.loaderOverlay.hide();
+      }
+    }
+  };
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -24,7 +25,9 @@ class MyApp extends ConsumerWidget {
 
     return GlobalLoaderOverlay(
       child: MaterialApp.router(
-        routerConfig: router.config(),
+        routerConfig: router.config(
+          navigatorObservers: () => [AutoRouteObserver()],
+        ),
         localizationsDelegates: const [
           GlobalMaterialLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,

--- a/frontend/lib/pages/errors/memo_error_with_refresh_page.dart
+++ b/frontend/lib/pages/errors/memo_error_with_refresh_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/models/memo.dart';
 import 'package:frontend/providers/memo_provider.dart';
+import 'package:frontend/widgets/error_with_refresh.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class MemoErrorWithRefreshPage extends ConsumerWidget {
@@ -13,18 +14,10 @@ class MemoErrorWithRefreshPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('エラー')),
       body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text('エラーが発生しました。やり直してください'),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () {
-                ref.invalidate(memoProvider(memoId));
-              },
-              child: const Text('再読み込み'),
-            ),
-          ],
+        child: ErrorWithRefresh(
+          onRefresh: () {
+            ref.invalidate(memoProvider(memoId));
+          },
         ),
       ),
     );

--- a/frontend/lib/pages/home_page.dart
+++ b/frontend/lib/pages/home_page.dart
@@ -1,16 +1,11 @@
-import 'dart:async';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:frontend/providers/repository_provider.dart';
-import 'package:frontend/router.gr.dart';
-import 'package:frontend/types/extensions/snack_bar.dart';
+import 'package:frontend/hooks/use_create_memo.dart';
 import 'package:frontend/widgets/destination_navigation_drawer.dart';
 import 'package:frontend/widgets/memo_text_field.dart';
 import 'package:frontend/widgets/record_button.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:loader_overlay/loader_overlay.dart';
 
 @RoutePage()
 class HomePage extends HookConsumerWidget {
@@ -22,27 +17,11 @@ class HomePage extends HookConsumerWidget {
     final textController = useTextEditingController();
     final focusNode = useFocusNode();
 
-    Future<void> submit(String raw) async {
-      context.loaderOverlay.show();
-      try {
-        final memo = await ref.read(memoRepositoryProvider).addMemo(raw);
-        textController.clear();
-        if (context.mounted) {
-          unawaited(context.router.push(MemoDetailsRoute(memoId: memo.id)));
-        }
-      } on Exception catch (e) {
-        debugPrint('Error adding memo: $e');
-        if (context.mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showErrorSnackBar(message: 'メモの追加に失敗しました。やり直してください');
-        }
-      } finally {
-        if (context.mounted) {
-          context.loaderOverlay.hide();
-        }
-      }
-    }
+    final submit = useCreateMemo(
+      context: context,
+      ref: ref,
+      afterCreate: textController.clear,
+    );
 
     return Scaffold(
       appBar: AppBar(title: const Text('ホーム')),

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -166,18 +166,12 @@ class _TagsHorizontalListView extends ConsumerWidget {
           tags.isLoading
               ? const Center(child: CircularProgressIndicator())
               : tags.hasError
-              ? Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                spacing: 8,
-                children: [
-                  const Text('タグの取得に失敗しました'),
-                  ElevatedButton(
-                    onPressed: () {
-                      ref.invalidate(tagListProvider);
-                    },
-                    child: const Text('再読み込み'),
-                  ),
-                ],
+              ? ErrorWithRefresh(
+                errorMessage: 'タグの取得に失敗しました',
+                onRefresh: () {
+                  ref.invalidate(tagListProvider);
+                },
+                isRow: true,
               )
               : ListView.separated(
                 padding: const EdgeInsets.symmetric(vertical: 8),

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -1,35 +1,27 @@
-import 'package:auto_route/annotations.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:frontend/constant.dart';
-import 'package:frontend/models/memo.dart';
-import 'package:frontend/models/memo_preview.dart';
+import 'package:frontend/hooks/use_create_memo.dart';
 import 'package:frontend/models/tag.dart';
+import 'package:frontend/providers/memo_list_provider.dart';
+import 'package:frontend/providers/memo_search_query_provider.dart';
+import 'package:frontend/providers/tag_list_provider.dart';
 import 'package:frontend/widgets/destination_navigation_drawer.dart';
 import 'package:frontend/widgets/dialogs/input_dialog.dart';
 import 'package:frontend/widgets/dialogs/record_dialog.dart';
 import 'package:frontend/widgets/dialogs/sort_dialog.dart';
+import 'package:frontend/widgets/error_with_refresh.dart';
 import 'package:frontend/widgets/memo_card.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 @RoutePage()
-class MemoListViewPage extends HookWidget {
+class MemoListViewPage extends HookConsumerWidget {
   const MemoListViewPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final mockMemoList = List.generate(
-      20,
-      (index) => MemoPreview(
-        id: MemoId(index),
-        title: 'メモタイトル$index',
-        body: 'だんだん長くなるメモの要約。' * (index + 1),
-        createdAt: DateTime.now(),
-      ),
-    );
-    final mockTagList = List.generate(
-      20,
-      (index) => Tag(id: TagId(index), name: 'タグ$index'),
-    );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memoList = ref.watch(memoListProvider);
 
     return Scaffold(
       drawer: const DestinationNavigationDrawer(),
@@ -41,21 +33,36 @@ class MemoListViewPage extends HookWidget {
           child: Column(
             spacing: 20,
             children: [
-              _TagsHorizontalListView(tags: mockTagList),
+              const _TagsHorizontalListView(),
               _SearchBar(),
               Expanded(
-                child: Scrollbar(
-                  child: ListView.separated(
-                    // FABの分大きめにpaddingをとる
-                    padding: const EdgeInsets.only(bottom: 180),
-                    separatorBuilder:
-                        (context, index) => const SizedBox(height: 20),
-                    itemCount: mockMemoList.length,
-                    itemBuilder:
-                        (context, index) =>
-                            MemoCard(memoPreview: mockMemoList[index]),
-                  ),
-                ),
+                child:
+                    memoList.isLoading
+                        ? const Center(child: CircularProgressIndicator())
+                        : memoList.hasError
+                        ? Center(
+                          child: ErrorWithRefresh(
+                            errorMessage: 'メモの取得に失敗しました。やり直してください',
+                            onRefresh: () {
+                              ref.invalidate(memoListProvider);
+                            },
+                          ),
+                        )
+                        : memoList.requireValue.isEmpty
+                        ? const Center(child: Text('メモがまだありません'))
+                        : Scrollbar(
+                          child: ListView.separated(
+                            // FABの分大きめにpaddingをとる
+                            padding: const EdgeInsets.only(bottom: 180),
+                            separatorBuilder:
+                                (context, index) => const SizedBox(height: 20),
+                            itemCount: memoList.requireValue.length,
+                            itemBuilder:
+                                (context, index) => MemoCard(
+                                  memoPreview: memoList.requireValue[index],
+                                ),
+                          ),
+                        ),
               ),
             ],
           ),
@@ -65,17 +72,23 @@ class MemoListViewPage extends HookWidget {
   }
 }
 
-class _AddMemoFab extends HookWidget {
+class _AddMemoFab extends HookConsumerWidget {
   const _AddMemoFab();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
 
     final isOpen = useState(false);
 
     const animationDuration = Duration(milliseconds: 300);
     const animationCurve = Curves.easeOut;
+
+    final submitNewMemo = useCreateMemo(
+      context: context,
+      ref: ref,
+      afterCreate: () => isOpen.value = false,
+    );
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -92,8 +105,7 @@ class _AddMemoFab extends HookWidget {
                 builder: (context) => const AddMemoFromTextDialog(),
               );
               if (rawMemo != null) {
-                // TODO(Rozelin-dc): メモ追加処理
-                debugPrint('テキストメモ追加: $rawMemo');
+                await submitNewMemo(rawMemo);
               }
             },
             child: const Icon(Icons.edit),
@@ -108,10 +120,9 @@ class _AddMemoFab extends HookWidget {
             heroTag: null,
             onPressed: () async {
               final transcription = await pickTranscribed(context);
-              if (transcription == null) return;
-
-              // TODO(Rozelin-dc): メモ追加処理
-              debugPrint('音声メモ追加: $transcription');
+              if (transcription != null) {
+                await submitNewMemo(transcription);
+              }
             },
             child: const Icon(Icons.mic),
           ),
@@ -141,74 +152,95 @@ class _AddMemoFab extends HookWidget {
   }
 }
 
-class _TagsHorizontalListView extends StatelessWidget {
-  const _TagsHorizontalListView({required this.tags});
-
-  final List<Tag> tags;
+class _TagsHorizontalListView extends ConsumerWidget {
+  const _TagsHorizontalListView();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    // TODO(sprint2): タグを全て取得するのではなく、数を絞りたい
+    final tags = ref.watch(tagListProvider);
+
     return SizedBox(
       height: 50,
-      child: ListView.separated(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        scrollDirection: Axis.horizontal,
-        itemCount: tags.length,
-        separatorBuilder: (context, index) => const SizedBox(width: 8),
-        itemBuilder: (context, index) {
-          final tag = tags[index];
-          return _TagChip(tag: tag);
-        },
-      ),
+      child:
+          tags.isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : tags.hasError
+              ? Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 8,
+                children: [
+                  const Text('タグの取得に失敗しました'),
+                  ElevatedButton(
+                    onPressed: () {
+                      ref.invalidate(tagListProvider);
+                    },
+                    child: const Text('再読み込み'),
+                  ),
+                ],
+              )
+              : ListView.separated(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                scrollDirection: Axis.horizontal,
+                itemCount: tags.requireValue.length,
+                separatorBuilder: (context, index) => const SizedBox(width: 8),
+                itemBuilder: (context, index) {
+                  final tag = tags.requireValue[index];
+                  return _TagChip(tag: tag);
+                },
+              ),
     );
   }
 }
 
-class _TagChip extends HookWidget {
+class _TagChip extends HookConsumerWidget {
   const _TagChip({required this.tag});
 
   final Tag tag;
 
   @override
-  Widget build(BuildContext context) {
-    final isSelected = useState(false);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isSelected = ref.watch(memoSearchTagNamesProvider).contains(tag.name);
+    final memoSearchTagNamesNotifier = ref.read(
+      memoSearchTagNamesProvider.notifier,
+    );
 
     return FilterChip(
       label: Text(tag.name),
-      selected: isSelected.value,
+      selected: isSelected,
       showCheckmark: false,
       onSelected: (value) {
-        // TODO(Rozelin-dc): タグタップによる検索の実装, https://github.com/HACK-U-2025-2/HACKU/issues/75
-        isSelected.value = true;
+        memoSearchTagNamesNotifier.addTagName(tag.name);
       },
       onDeleted:
           // 選択されていない時に削除ボタンが出ないように
-          isSelected.value
+          isSelected
               ? () {
-                isSelected.value = false;
+                memoSearchTagNamesNotifier.removeTagName(tag.name);
               }
               : null,
     );
   }
 }
 
-class _SearchBar extends HookWidget {
+class _SearchBar extends HookConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final searchText = useState('');
     final debouncedSearchText = useDebounced(
       searchText.value,
       const Duration(milliseconds: searchRequestDurationMilliseconds),
     );
     useEffect(() {
-      // TODO(Rozelin-dc): 検索処理, https://github.com/HACK-U-2025-2/HACKU/issues/75
-      debugPrint('Search text: $debouncedSearchText');
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref
+            .read(memoSearchKeywordProvider.notifier)
+            .setKeyword(debouncedSearchText ?? '');
+      });
       return null;
     }, [debouncedSearchText]);
 
-    final sortOption = useState(
-      MemoSortOption(mode: MemoSortMode.createdAt, isAsc: true),
-    );
+    final sortOption = ref.watch(memoSearchSortOptionProvider);
 
     return SearchBar(
       leading: const Icon(Icons.search),
@@ -219,13 +251,19 @@ class _SearchBar extends HookWidget {
             final newSortOption = await showDialog<MemoSortOption?>(
               context: context,
               builder:
-                  (context) =>
-                      MemoSortDialog(initialSortOption: sortOption.value),
+                  (context) => MemoSortDialog(
+                    initialSortOption:
+                        sortOption ??
+                        MemoSortOption(
+                          isAsc: true,
+                          mode: MemoSortMode.createdAt,
+                        ),
+                  ),
             );
             if (newSortOption != null) {
-              // TODO(Rozelin-dc): ソート処理
-              sortOption.value = newSortOption;
-              debugPrint('ソートオプション: ${sortOption.value}');
+              ref
+                  .read(memoSearchSortOptionProvider.notifier)
+                  .setSortOption(newSortOption);
             }
           },
         ),

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -16,11 +16,26 @@ import 'package:frontend/widgets/memo_card.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 @RoutePage()
-class MemoListViewPage extends HookConsumerWidget {
+class MemoListViewPage extends StatefulHookConsumerWidget {
   const MemoListViewPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MemoListViewPage> createState() => _MemoListViewPageState();
+}
+
+class _MemoListViewPageState extends ConsumerState<MemoListViewPage>
+    with AutoRouteAwareStateMixin {
+  @override
+  void didPopNext() {
+    super.didPopNext();
+    // ページに戻ってきたときにメモとタグの一覧を再取得
+    ref
+      ..invalidate(memoListProvider)
+      ..invalidate(tagListProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final memoList = ref.watch(memoListProvider);
 
     return Scaffold(

--- a/frontend/lib/pages/memo_list_view_page.dart
+++ b/frontend/lib/pages/memo_list_view_page.dart
@@ -251,14 +251,7 @@ class _SearchBar extends HookConsumerWidget {
             final newSortOption = await showDialog<MemoSortOption?>(
               context: context,
               builder:
-                  (context) => MemoSortDialog(
-                    initialSortOption:
-                        sortOption ??
-                        MemoSortOption(
-                          isAsc: true,
-                          mode: MemoSortMode.createdAt,
-                        ),
-                  ),
+                  (context) => MemoSortDialog(initialSortOption: sortOption),
             );
             if (newSortOption != null) {
               ref

--- a/frontend/lib/providers/memo_list_provider.dart
+++ b/frontend/lib/providers/memo_list_provider.dart
@@ -1,0 +1,22 @@
+import 'package:frontend/models/memo_preview.dart';
+import 'package:frontend/providers/memo_search_query_provider.dart';
+import 'package:frontend/providers/repository_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'memo_list_provider.g.dart';
+
+@riverpod
+Future<List<MemoPreview>> memoList(Ref ref) async {
+  final keywordQuery = ref.watch(memoSearchKeywordProvider);
+  final tagNamesQuery = ref.watch(memoSearchTagNamesProvider);
+  final sortOptionQuery = ref.watch(memoSearchSortOptionProvider);
+
+  return ref
+      .watch(memoRepositoryProvider)
+      .getMemos(
+        keyword: keywordQuery,
+        tagNames: tagNamesQuery,
+        sort: sortOptionQuery,
+      );
+}

--- a/frontend/lib/providers/memo_list_provider.g.dart
+++ b/frontend/lib/providers/memo_list_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'memo_list_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$memoListHash() => r'433aa32dcbbf675818d3933ac0761ae48e33f641';
+
+/// See also [memoList].
+@ProviderFor(memoList)
+final memoListProvider = AutoDisposeFutureProvider<List<MemoPreview>>.internal(
+  memoList,
+  name: r'memoListProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$memoListHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef MemoListRef = AutoDisposeFutureProviderRef<List<MemoPreview>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/providers/memo_search_query_provider.dart
+++ b/frontend/lib/providers/memo_search_query_provider.dart
@@ -39,8 +39,7 @@ class MemoSearchTagNames extends _$MemoSearchTagNames {
 class MemoSearchSortOption extends _$MemoSearchSortOption {
   @override
   MemoSortOption build() {
-    // TODO: デフォルトのソートオプションについてサーバーと合意を取る
-    return MemoSortOption(isAsc: true, mode: MemoSortMode.createdAt);
+    return MemoSortOption(isAsc: false, mode: MemoSortMode.createdAt);
   }
 
   void setSortOption(MemoSortOption sortOption) {

--- a/frontend/lib/providers/memo_search_query_provider.dart
+++ b/frontend/lib/providers/memo_search_query_provider.dart
@@ -1,0 +1,48 @@
+import 'package:frontend/widgets/dialogs/sort_dialog.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'memo_search_query_provider.g.dart';
+
+@riverpod
+class MemoSearchKeyword extends _$MemoSearchKeyword {
+  @override
+  String build() {
+    return '';
+  }
+
+  void setKeyword(String keyword) {
+    state = keyword;
+  }
+}
+
+@riverpod
+class MemoSearchTagNames extends _$MemoSearchTagNames {
+  @override
+  List<String> build() {
+    return [];
+  }
+
+  void addTagName(String tagName) {
+    state = [...state, tagName];
+  }
+
+  void removeTagName(String tagName) {
+    state = state.where((name) => name != tagName).toList();
+  }
+
+  void clearTagNames() {
+    state = [];
+  }
+}
+
+@riverpod
+class MemoSearchSortOption extends _$MemoSearchSortOption {
+  @override
+  MemoSortOption? build() {
+    return null;
+  }
+
+  void setSortOption(MemoSortOption? sortOption) {
+    state = sortOption;
+  }
+}

--- a/frontend/lib/providers/memo_search_query_provider.dart
+++ b/frontend/lib/providers/memo_search_query_provider.dart
@@ -38,11 +38,12 @@ class MemoSearchTagNames extends _$MemoSearchTagNames {
 @riverpod
 class MemoSearchSortOption extends _$MemoSearchSortOption {
   @override
-  MemoSortOption? build() {
-    return null;
+  MemoSortOption build() {
+    // TODO: デフォルトのソートオプションについてサーバーと合意を取る
+    return MemoSortOption(isAsc: true, mode: MemoSortMode.createdAt);
   }
 
-  void setSortOption(MemoSortOption? sortOption) {
+  void setSortOption(MemoSortOption sortOption) {
     state = sortOption;
   }
 }

--- a/frontend/lib/providers/memo_search_query_provider.g.dart
+++ b/frontend/lib/providers/memo_search_query_provider.g.dart
@@ -42,12 +42,12 @@ final memoSearchTagNamesProvider =
 
 typedef _$MemoSearchTagNames = AutoDisposeNotifier<List<String>>;
 String _$memoSearchSortOptionHash() =>
-    r'd8551dc930bfbc63bce94c9fd0c99fca7ef26a88';
+    r'53888895c79bac4b53e3cab7a5feeb0ddb4fa7fd';
 
 /// See also [MemoSearchSortOption].
 @ProviderFor(MemoSearchSortOption)
 final memoSearchSortOptionProvider =
-    AutoDisposeNotifierProvider<MemoSearchSortOption, MemoSortOption?>.internal(
+    AutoDisposeNotifierProvider<MemoSearchSortOption, MemoSortOption>.internal(
       MemoSearchSortOption.new,
       name: r'memoSearchSortOptionProvider',
       debugGetCreateSourceHash:
@@ -58,6 +58,6 @@ final memoSearchSortOptionProvider =
       allTransitiveDependencies: null,
     );
 
-typedef _$MemoSearchSortOption = AutoDisposeNotifier<MemoSortOption?>;
+typedef _$MemoSearchSortOption = AutoDisposeNotifier<MemoSortOption>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/providers/memo_search_query_provider.g.dart
+++ b/frontend/lib/providers/memo_search_query_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'memo_search_query_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$memoSearchKeywordHash() => r'f15b47884229840884852c7c943027a6b351e228';
+
+/// See also [MemoSearchKeyword].
+@ProviderFor(MemoSearchKeyword)
+final memoSearchKeywordProvider =
+    AutoDisposeNotifierProvider<MemoSearchKeyword, String>.internal(
+      MemoSearchKeyword.new,
+      name: r'memoSearchKeywordProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$memoSearchKeywordHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$MemoSearchKeyword = AutoDisposeNotifier<String>;
+String _$memoSearchTagNamesHash() =>
+    r'207d5ea82a956aeb2378a78617ffd275e765188b';
+
+/// See also [MemoSearchTagNames].
+@ProviderFor(MemoSearchTagNames)
+final memoSearchTagNamesProvider =
+    AutoDisposeNotifierProvider<MemoSearchTagNames, List<String>>.internal(
+      MemoSearchTagNames.new,
+      name: r'memoSearchTagNamesProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$memoSearchTagNamesHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$MemoSearchTagNames = AutoDisposeNotifier<List<String>>;
+String _$memoSearchSortOptionHash() =>
+    r'd8551dc930bfbc63bce94c9fd0c99fca7ef26a88';
+
+/// See also [MemoSearchSortOption].
+@ProviderFor(MemoSearchSortOption)
+final memoSearchSortOptionProvider =
+    AutoDisposeNotifierProvider<MemoSearchSortOption, MemoSortOption?>.internal(
+      MemoSearchSortOption.new,
+      name: r'memoSearchSortOptionProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$memoSearchSortOptionHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$MemoSearchSortOption = AutoDisposeNotifier<MemoSortOption?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/providers/tag_list_provider.dart
+++ b/frontend/lib/providers/tag_list_provider.dart
@@ -1,0 +1,11 @@
+import 'package:frontend/models/tag.dart';
+import 'package:frontend/providers/repository_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'tag_list_provider.g.dart';
+
+@riverpod
+Future<List<Tag>> tagList(Ref ref) async {
+  return ref.watch(memoRepositoryProvider).getTags();
+}

--- a/frontend/lib/providers/tag_list_provider.g.dart
+++ b/frontend/lib/providers/tag_list_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'tag_list_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$tagListHash() => r'f56061be7d5528ae8e58d69354ab1ae9b0f20ce1';
+
+/// See also [tagList].
+@ProviderFor(tagList)
+final tagListProvider = AutoDisposeFutureProvider<List<Tag>>.internal(
+  tagList,
+  name: r'tagListProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$tagListHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef TagListRef = AutoDisposeFutureProviderRef<List<Tag>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/repositories/memo_repository/api_client_memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/api_client_memo_repository.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/memo_preview.dart';
+import 'package:frontend/models/tag.dart';
 import 'package:frontend/repositories/auth_repository/auth_repository.dart';
 import 'package:frontend/repositories/memo_repository/memo_repository.dart';
 import 'package:frontend/services/client/memo_api_client.dart';
@@ -89,6 +90,15 @@ class ApiClientMemoRepository implements MemoRepository {
       await _memoApiClient.deleteMemo(memoId: id.value);
     } on DioException catch (e) {
       throw _handleDioException(e, id);
+    }
+  }
+
+  @override
+  Future<List<Tag>> getTags({String? keyword}) async {
+    try {
+      return await _memoApiClient.getTags(keyword: keyword);
+    } on DioException catch (e) {
+      throw _handleDioException(e, null);
     }
   }
 }

--- a/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/in_memory_memo_repository.dart
@@ -119,6 +119,14 @@ class InMemoryMemoRepository implements MemoRepository {
     if (_memos.remove(id) == null) throw MemoNotFoundException(id);
   }
 
+  @override
+  Future<List<Tag>> getTags({String? keyword}) async {
+    if (keyword == null || keyword.isEmpty) {
+      return _tags.values.toList();
+    }
+    return _tags.values.where((tag) => tag.name.contains(keyword)).toList();
+  }
+
   // メモの更新処理を共通化、非同期処理にしている
   Future<void> _updateMemo(MemoId id, Memo Function(Memo) update) async {
     final memo = _memos[id];

--- a/frontend/lib/repositories/memo_repository/memo_repository.dart
+++ b/frontend/lib/repositories/memo_repository/memo_repository.dart
@@ -1,5 +1,6 @@
 import 'package:frontend/models/memo.dart';
 import 'package:frontend/models/memo_preview.dart';
+import 'package:frontend/models/tag.dart';
 import 'package:frontend/widgets/dialogs/sort_dialog.dart';
 
 export 'package:frontend/types/request_body.dart';
@@ -29,6 +30,9 @@ abstract interface class MemoRepository {
 
   /// メモを削除する
   Future<void> deleteMemo(MemoId id);
+
+  /// タグの一覧を取得する
+  Future<List<Tag>> getTags({String? keyword});
 }
 
 class MemoNotFoundException implements Exception {

--- a/frontend/lib/widgets/dialogs/sort_dialog.dart
+++ b/frontend/lib/widgets/dialogs/sort_dialog.dart
@@ -64,9 +64,9 @@ class MemoSortDialog extends HookWidget {
             ),
           ),
           RadioListTile(
-            value: true,
+            value: false,
             groupValue: isAsc.value,
-            title: const Text('昇順'),
+            title: const Text('降順'),
             onChanged: (value) {
               if (value != null) {
                 isAsc.value = value;
@@ -75,9 +75,9 @@ class MemoSortDialog extends HookWidget {
             contentPadding: EdgeInsets.zero,
           ),
           RadioListTile(
-            value: false,
+            value: true,
             groupValue: isAsc.value,
-            title: const Text('降順'),
+            title: const Text('昇順'),
             onChanged: (value) {
               if (value != null) {
                 isAsc.value = value;

--- a/frontend/lib/widgets/error_with_refresh.dart
+++ b/frontend/lib/widgets/error_with_refresh.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class ErrorWithRefresh extends StatelessWidget {
+  const ErrorWithRefresh({
+    required this.onRefresh,
+    this.errorMessage = 'エラーが発生しました。やり直してください',
+    super.key,
+  });
+
+  final VoidCallback onRefresh;
+  final String errorMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(errorMessage),
+        const SizedBox(height: 16),
+        ElevatedButton(onPressed: onRefresh, child: const Text('再読み込み')),
+      ],
+    );
+  }
+}

--- a/frontend/lib/widgets/error_with_refresh.dart
+++ b/frontend/lib/widgets/error_with_refresh.dart
@@ -4,21 +4,31 @@ class ErrorWithRefresh extends StatelessWidget {
   const ErrorWithRefresh({
     required this.onRefresh,
     this.errorMessage = 'エラーが発生しました。やり直してください',
+    this.isRow = false,
     super.key,
   });
 
   final VoidCallback onRefresh;
   final String errorMessage;
+  final bool isRow;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(errorMessage),
-        const SizedBox(height: 16),
-        ElevatedButton(onPressed: onRefresh, child: const Text('再読み込み')),
-      ],
-    );
+    final children = [
+      Text(errorMessage),
+      ElevatedButton(onPressed: onRefresh, child: const Text('再読み込み')),
+    ];
+
+    return isRow
+        ? Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          spacing: 8,
+          children: children,
+        )
+        : Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: children,
+        );
   }
 }


### PR DESCRIPTION
close #75 
relate #21 

## 概要
- メモ一覧ページのAPI接続を行いました
- 検索用のクエリはproviderで管理するようにしました
  - sprint2でタグ一覧ページから検索ページに飛んだりすることを想定しての設計です
  - メモ詳細画面から戻ってきたときに検索状態がそのままの方が嬉しいかなと思ってクエリのクリアはしていません
  - `.g.dart` ファイルは自動生成されたものなので見なくて大丈夫です
- エラー時の表示とメモ作成の処理はホーム画面と共通なので別ファイルに切り出しました
 
## 相談
現状だとメモ一覧画面からメモを追加した場合や、タグを追加した後の状態が反映されません。ページ遷移から戻ってきたときにメモ一覧とタグ一覧を再取得できればいいなと思ったのですが、いいやり方が分からず困っているので、何か知見があれば教えていただきたいです