### PR TITLE
feat: 埋め込みモデルのモック実装と微修正

### DIFF
--- a/backend/docker-compose.override.yml
+++ b/backend/docker-compose.override.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     environment:
-      USE_MOCK_LLM: "False"
+      USE_MOCK_MODEL: "False"
     volumes:
       - .:/app
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     environment:
-      USE_MOCK_LLM: "True"
+      USE_MOCK_MODEL: "True"
     volumes:
       - .:/app
 

--- a/backend/embedding/embedding.py
+++ b/backend/embedding/embedding.py
@@ -1,3 +1,5 @@
+import random
+
 import torch
 
 from .loader import load_embedding_model
@@ -9,6 +11,10 @@ def get_embedding(text: str) -> list:
     """
     model, tokenizer = load_embedding_model()
     device = next(model.parameters()).device
+
+    if model == "mock_model":
+        EMBEDDING_DIM = 1024  # 本番の埋め込み次元数に合わせてください
+        return [random.uniform(-1, 1) for _ in range(EMBEDDING_DIM)]
 
     with torch.no_grad():
         # トークナイズしてデバイスへ転送

--- a/backend/embedding/embedding.py
+++ b/backend/embedding/embedding.py
@@ -13,7 +13,7 @@ def get_embedding(text: str) -> list:
     device = next(model.parameters()).device
 
     if model == "mock_model":
-        EMBEDDING_DIM = 1024  # 本番の埋め込み次元数に合わせてください
+        EMBEDDING_DIM = 1024
         return [random.uniform(-1, 1) for _ in range(EMBEDDING_DIM)]
 
     with torch.no_grad():

--- a/backend/embedding/embedding.py
+++ b/backend/embedding/embedding.py
@@ -10,11 +10,12 @@ def get_embedding(text: str) -> list:
     テキストをモデルで埋め込みベクトル化し、リストで返します。
     """
     model, tokenizer = load_embedding_model()
-    device = next(model.parameters()).device
 
     if model == "mock_model":
         EMBEDDING_DIM = 1024
         return [random.uniform(-1, 1) for _ in range(EMBEDDING_DIM)]
+
+    device = next(model.parameters()).device
 
     with torch.no_grad():
         # トークナイズしてデバイスへ転送

--- a/backend/embedding/loader.py
+++ b/backend/embedding/loader.py
@@ -14,7 +14,7 @@ def load_embedding_model():
     BAAI/bge-m3 モデルとトークナイザーをキャッシュして返す。
     GPU があれば float16、なければ float32 でロードし、適切なデバイスに配置。
     """
-    global _embedding_model, _embedding_tokenizer  # ←★追加！
+    global _embedding_model, _embedding_tokenizer
 
     if _embedding_model is None or _embedding_tokenizer is None:
         use_mock = os.getenv("USE_MOCK_MODEL", "false").lower() == "true"

--- a/backend/embedding/loader.py
+++ b/backend/embedding/loader.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 from transformers import AutoModel, AutoTokenizer
 
@@ -12,18 +14,24 @@ def load_embedding_model():
     BAAI/bge-m3 モデルとトークナイザーをキャッシュして返す。
     GPU があれば float16、なければ float32 でロードし、適切なデバイスに配置。
     """
-    global _embedding_model, _embedding_tokenizer
-    # 未ロード時のみ初期化
+    global _embedding_model, _embedding_tokenizer  # ←★追加！
+
     if _embedding_model is None or _embedding_tokenizer is None:
-        # 利用可能なら GPU、なければ CPU
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        # トークナイザー読み込み
-        _embedding_tokenizer = AutoTokenizer.from_pretrained(
-            _embedding_model_name, force_download=True
-        )
-        # モデル読み込み (GPU 時は半精度で)
-        dtype = torch.float16 if device == "cuda" else torch.float32
-        _embedding_model = AutoModel.from_pretrained(
-            _embedding_model_name, torch_dtype=dtype, force_download=True
-        ).to(device)
+        use_mock = os.getenv("USE_MOCK_MODEL", "false").lower() == "true"
+
+        if use_mock:
+            _embedding_model = "mock_model"
+            _embedding_tokenizer = "mock_tokenizer"
+        else:
+            # 利用可能なら GPU、なければ CPU
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            # トークナイザー読み込み
+            _embedding_tokenizer = AutoTokenizer.from_pretrained(
+                _embedding_model_name, force_download=False
+            )
+            # モデル読み込み (GPU 時は半精度で)
+            dtype = torch.float16 if device == "cuda" else torch.float32
+            _embedding_model = AutoModel.from_pretrained(
+                _embedding_model_name, torch_dtype=dtype, force_download=False
+            ).to(device)
     return _embedding_model, _embedding_tokenizer

--- a/backend/llm/generate_title.py
+++ b/backend/llm/generate_title.py
@@ -10,5 +10,5 @@ def generate_title(text: str) -> str:
 # 文章
 {text}
 """
-    json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=12)
+    json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=64)
     return parse_json(json_text)

--- a/backend/llm/generate_title.py
+++ b/backend/llm/generate_title.py
@@ -10,5 +10,5 @@ def generate_title(text: str) -> str:
 # 文章
 {text}
 """
-    json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=64)
+    json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=128)
     return parse_json(json_text)

--- a/backend/llm/utils/generator.py
+++ b/backend/llm/utils/generator.py
@@ -6,7 +6,7 @@ from llm.utils.loader import load_llm_model
 def generate_text(prompt: str, enable_thinking: bool, max_new_tokens: int) -> str:
     model, tokenizer = load_llm_model()
 
-    if model == "mock_llm":
+    if model == "mock_model":
         clean_prompt = prompt.replace("\n", "")
         mock_result = f"モック応答（プロンプト: {clean_prompt[:25]}...）"
         return json.dumps({"result": mock_result})

--- a/backend/llm/utils/loader.py
+++ b/backend/llm/utils/loader.py
@@ -25,7 +25,9 @@ def load_llm_model():
             _model = "mock_model"
             _tokenizer = "mock_tokenizer"
         else:
-            _tokenizer = AutoTokenizer.from_pretrained(_model_name, force_download=False)
+            _tokenizer = AutoTokenizer.from_pretrained(
+                _model_name, force_download=False
+            )
             _model = AutoModelForCausalLM.from_pretrained(
                 _model_name, torch_dtype="auto", device_map="auto", force_download=False
             )

--- a/backend/llm/utils/loader.py
+++ b/backend/llm/utils/loader.py
@@ -13,21 +13,21 @@ _model_name = "Qwen/Qwen3-4B"
 def load_llm_model():
     """
     モデルとトークナイザーを一度だけロードして返す。
-    環境変数 `USE_MOCK_LLM=true` の場合はモックを返し、falseの場合はモデルをロードする。
+    環境変数 `USE_MOCK_MODEL=true` の場合はモックを返し、falseの場合はモデルをロードする。
     """
     global _model, _tokenizer
 
     if _model is None or _tokenizer is None:
-        use_mock = os.getenv("USE_MOCK_LLM", "false").lower() == "true"
-        logger.warning("INFO:     USE_MOCK_LLM = %s", use_mock)
+        use_mock = os.getenv("USE_MOCK_MODEL", "false").lower() == "true"
+        logger.warning("USE_MOCK_MODEL = %s", use_mock)
 
         if use_mock:
-            _model = "mock_llm"
+            _model = "mock_model"
             _tokenizer = "mock_tokenizer"
         else:
-            _tokenizer = AutoTokenizer.from_pretrained(_model_name, force_download=True)
+            _tokenizer = AutoTokenizer.from_pretrained(_model_name, force_download=False)
             _model = AutoModelForCausalLM.from_pretrained(
-                _model_name, torch_dtype="auto", device_map="auto", force_download=True
+                _model_name, torch_dtype="auto", device_map="auto", force_download=False
             )
 
     return _model, _tokenizer

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,19 +44,3 @@ app.include_router(auth.router)
 app.include_router(tag.router)
 app.include_router(memo.router)
 app.include_router(memo_websocket.router)
-
-if __name__ == "__main__":
-    from llm.summarize_text import summarize_text
-
-    print("-" * 10, "summarize_text", "-" * 10)
-    print(
-        summarize_text(
-            "夜の村で何か起きるみたいな感じのやつでも全部がそうじゃなくてなんか選ばれた人だけっていうか理由はまだよくわかんないけど昔の話とか関係あるかもで少年がその中に入ってうーん"
-        )
-    )
-
-    from embedding.embedding import get_embedding
-    from embedding.reduce_to_3d import embedding_to_3d_unit
-
-    x = get_embedding("夜の村で何か起きるみたいな感じ")
-    print(embedding_to_3d_unit(x))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import asynccontextmanager
 
 from embedding.loader import load_embedding_model
@@ -5,12 +6,28 @@ from fastapi import FastAPI
 from llm.utils.loader import load_llm_model
 from routers import auth, memo, memo_websocket, tag
 
+logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # サーバ起動時に一度だけモデルをロード
-    load_llm_model()
+    # ── ① モデル類をロード ─────────────────────────────
+    model, tokenizer = load_llm_model()
     load_embedding_model()
+
+    # ── ② ウォームアップ ────────────────────────────────
+    #    1 トークンだけ生成して KV キャッシュ確保 & カーネル JIT を済ませる
+    try:
+        # モックならウォームアップ不要
+        if model != "mock_llm":
+            dummy = tokenizer("<warmup>", return_tensors="pt").to(model.device)
+            model.generate(**dummy, max_new_tokens=1)
+            logger.warning("LLM warm-up completed")
+        else:
+            logger.warning("LLM warm-up skipped (mock mode)")
+    except Exception as e:
+        logger.warning("LLM warm-up skipped: %s", e)
+
+    # ── ③ アプリ起動へ ────────────────────────────────
     yield
 
 
@@ -26,3 +43,15 @@ app.include_router(auth.router)
 app.include_router(tag.router)
 app.include_router(memo.router)
 app.include_router(memo_websocket.router)
+
+if __name__ == "__main__":
+    from llm.summarize_text import summarize_text
+
+    print("-"*10, "summarize_text","-"*10)
+    print(summarize_text("夜の村で何か起きるみたいな感じのやつでも全部がそうじゃなくてなんか選ばれた人だけっていうか理由はまだよくわかんないけど昔の話とか関係あるかもで少年がその中に入ってうーん"))
+
+    from embedding.embedding import get_embedding
+    from embedding.reduce_to_3d import embedding_to_3d_unit
+
+    x = get_embedding("夜の村で何か起きるみたいな感じ")
+    print(embedding_to_3d_unit(x))

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from routers import auth, memo, memo_websocket, tag
 
 logger = logging.getLogger(__name__)
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # ── ① モデル類をロード ─────────────────────────────
@@ -47,8 +48,12 @@ app.include_router(memo_websocket.router)
 if __name__ == "__main__":
     from llm.summarize_text import summarize_text
 
-    print("-"*10, "summarize_text","-"*10)
-    print(summarize_text("夜の村で何か起きるみたいな感じのやつでも全部がそうじゃなくてなんか選ばれた人だけっていうか理由はまだよくわかんないけど昔の話とか関係あるかもで少年がその中に入ってうーん"))
+    print("-" * 10, "summarize_text", "-" * 10)
+    print(
+        summarize_text(
+            "夜の村で何か起きるみたいな感じのやつでも全部がそうじゃなくてなんか選ばれた人だけっていうか理由はまだよくわかんないけど昔の話とか関係あるかもで少年がその中に入ってうーん"
+        )
+    )
 
     from embedding.embedding import get_embedding
     from embedding.reduce_to_3d import embedding_to_3d_unit

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 transformers==4.51.3
 numpy==1.25.2
+scikit-learn
 hf_xet
 alembic
 accelerate


### PR DESCRIPTION
close #234 
relate #221

- 埋め込みモデルのモック実装
- 微修正
    - generate_textのmax_new_tokensの最大値を引き上げ
    - サーバ起動時にLLMの「ウォームアップ」を実行(これにより、以降の推論処理ではウォームアップ時に生成されたキャッシュが利用され、レスポンスが高速化されます)
    - backend/requirements.txtにscikit-learnを追加(1024d -> 3d 変換時に使用)

手元でGPU版CPU版のdockerビルドやuse_mock_model=true時の関数の動作を確認済みです。