### PR TITLE
feat: generate_tags関数の追加

### DIFF
--- a/backend/llm/generate_tags.py
+++ b/backend/llm/generate_tags.py
@@ -2,14 +2,35 @@ from llm.utils.generator import generate_text
 from llm.utils.parser import parse_json
 
 
-def generate_tags(text: str) -> list[str]:
+def generate_tags(
+    new_text: str,
+    initial_tags: list[str] = None,
+    related_text: str = None,  # ここをstr型に
+    related_tags: list[str] = None,  # ここをlist[str]型に
+) -> list[str]:
+    """
+    メモ追加時のタグ生成アシスタント関数。
+    """
+    initial_tags = initial_tags or []
+    related_text = related_text or ""
+    related_tags = related_tags or []
+    already_tags = set(initial_tags)
+
+    # tags（除外したいタグ）が空でなければ、それらを除外するようLLMへの指示文を設計する
+    def format_exclude_tags_instruction(tags: set[str]) -> str:
+        if tags:
+            return f"- 既に含まれるタグ（{', '.join(tags)}）は除外してください。"
+        return ""
+
     # メジャータグ抽出
-    def extract_major_tags(text: str) -> list[str]:
+    def extract_major_tags(text: str, exclude_tags: set[str]) -> list[str]:
+        exclude_instruction = format_exclude_tags_instruction(exclude_tags)
         prompt = f"""
 # 指示
 あなたはメモ分類アシスタントです。
 以下のメモ本文から、該当する「メジャータグ」を**必要なだけ全て**選んでください。
-- メジャータグ：「アイデア、ヒント、日記、ToDo、旅行、食事、人間関係、イベント、買い物、予定」
+- メジャータグ：「アイデア、日記、ToDo、イベント」
+{exclude_instruction}
 
 # 出力形式 該当がなければ空リスト
 {{"result": "タグ1, タグ2, タグ3"}}
@@ -17,22 +38,23 @@ def generate_tags(text: str) -> list[str]:
 # メモ本文
 {text}
 """
-        json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=128)
-        tag_str = parse_json(json_text)
+        tag_str = parse_json(
+            generate_text(prompt, enable_thinking=False, max_new_tokens=128)
+        )
         if isinstance(tag_str, str):
-            tags = [t.strip() for t in tag_str.split(",") if t.strip()]
-        elif isinstance(tag_str, list):
-            tags = [t.strip() for t in tag_str if t.strip()]
-        else:
-            tags = []
-        return tags
+            return [t.strip() for t in tag_str.split(",") if t.strip()]
+        if isinstance(tag_str, list):
+            return [t.strip() for t in tag_str if t.strip()]
+        return []
 
     # カスタムタグ抽出
-    def extract_custom_tags(text: str) -> list[str]:
+    def extract_custom_tags(text: str, exclude_tags: set[str]) -> list[str]:
+        exclude_instruction = format_exclude_tags_instruction(exclude_tags)
         prompt = f"""
 # 指示
 あなたはメモ分類アシスタントです。
-以下のメモ本文から、人名以外の固有名詞（例：地名、商品名、施設名、イベント名、キーワードなど）を「カスタムタグ」としてすべて抽出してください。
+以下のメモ本文から、人名以外の固有名詞（例：地名、商品名、施設名、イベント名、キーワードなど）をすべて抽出してください。
+{exclude_instruction}
 
 # 出力形式 該当がなければ空リスト
 {{"result": "タグ1, タグ2, タグ3"}}
@@ -40,22 +62,21 @@ def generate_tags(text: str) -> list[str]:
 # メモ本文
 {text}
 """
-        json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=128)
-        tag_str = parse_json(json_text)
+        tag_str = parse_json(
+            generate_text(prompt, enable_thinking=False, max_new_tokens=128)
+        )
         if isinstance(tag_str, str):
-            tags = [t.strip() for t in tag_str.split(",") if t.strip()]
-        elif isinstance(tag_str, list):
-            tags = [t.strip() for t in tag_str if t.strip()]
-        else:
-            tags = []
-        return tags
+            return [t.strip() for t in tag_str.split(",") if t.strip()]
+        if isinstance(tag_str, list):
+            return [t.strip() for t in tag_str if t.strip()]
+        return []
 
-    # アイデア種別の分類
+    # アイデア種別分類
     def classify_idea_type(text: str) -> str:
         prompt = f"""
 # 指示
 次のメモがどの分野やカテゴリの「アイデア」か、1つの短い単語で答えてください。
-例：「アプリ」「サービス」「イベント」「商品」「仕事」「週間」「企画」「研究」「デザイン」「ストーリー」など
+例：「アプリ」「サービス」「イベント」「商品」「仕事」「企画」「研究」「デザイン」「ストーリー」など
 該当するものがない場合は"None"を返してください。
 
 # メモ本文
@@ -65,31 +86,79 @@ def generate_tags(text: str) -> list[str]:
 例1: {{"result": "健康"}}
 例2: {{"result": "None"}}
 """
-        json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=64)
-        category = parse_json(json_text)
+        category = parse_json(
+            generate_text(prompt, enable_thinking=False, max_new_tokens=64)
+        )
         if isinstance(category, str):
-            category = category.strip()
-            # None, "None", 空文字列は除外
-            if category and category.lower() != "none":
-                return category
+            cat = category.strip()
+            if cat and cat.lower() != "none":
+                return cat
         return ""
 
-    # タグ取得
-    major_tags = extract_major_tags(text)
+    # 関連メモ由来タグの提案（ここを単一に変更）
+    def suggest_related_tags(
+        text: str, rel_text: str, rel_tags: list[str], exclude_tags: set[str]
+    ) -> list[str]:
+        if not rel_text or not rel_tags:
+            return []
+        exclude_instruction = format_exclude_tags_instruction(exclude_tags)
+        formatted = f"- 本文: {rel_text}\n  タグ: {', '.join(rel_tags)}"
+        prompt = f"""
+# 指示
+あなたはメモ分類アシスタントです。
+追加されるメモ本文と関連メモの情報を参考に、
+**追加すべきタグ**を必要なだけ提案してください。
+{exclude_instruction}
 
-    # アイデアタグがあれば種別分類
-    idea_category = None
-    if "アイデア" in major_tags:
-        idea_category = classify_idea_type(text)
+# 追加されるメモ本文
+{text}
 
-    custom_tags = extract_custom_tags(text)
+# 関連メモ
+{formatted}
 
-    # アイデア分類結果をメジャータグの次に追加
-    all_tags = major_tags.copy()
-    if idea_category and idea_category not in all_tags:
-        all_tags.append(idea_category)
-    all_tags += [tag for tag in custom_tags if tag not in all_tags]
+# 出力形式
+{{"result": "タグ1, タグ2, タグ3"}}
+"""
+        tag_str = parse_json(
+            generate_text(prompt, enable_thinking=False, max_new_tokens=128)
+        )
+        if isinstance(tag_str, str):
+            return [t.strip() for t in tag_str.split(",") if t.strip()]
+        if isinstance(tag_str, list):
+            return [t.strip() for t in tag_str if t.strip()]
+        return []
 
-    # 重複排除
-    all_tags = list(dict.fromkeys(all_tags))
-    return all_tags
+    # メインのタグ生成処理
+    tags_result: list[str] = list(initial_tags)
+
+    # メジャータグ
+    major_tags = extract_major_tags(new_text, already_tags)
+    tags_result += [t for t in major_tags if t not in already_tags]
+    already_tags.update(major_tags)
+
+    # アイデア区分追加
+    # initial_tagsに「アイデア」が含まれる場合は「アイデア」を残して区分を追加、major_tagsに含まれる場合は置換
+    idea_in_initial = "アイデア" in (initial_tags or [])
+    idea_in_major = "アイデア" in major_tags
+
+    if idea_in_initial or idea_in_major:
+        idea_category = classify_idea_type(new_text)
+        if idea_category and idea_category not in already_tags:
+            tags_result.append(idea_category)
+            already_tags.add(idea_category)
+        # 置換はmajor_tagsに「アイデア」があってinitial_tagsにない場合のみ
+        if idea_in_major and not idea_in_initial:
+            tags_result = [t for t in tags_result if t != "アイデア"]
+
+    # カスタムタグ
+    custom_tags = extract_custom_tags(new_text, already_tags)
+    tags_result += [t for t in custom_tags if t not in already_tags]
+    already_tags.update(custom_tags)
+
+    # 関連メモタグ
+    related_suggestions = suggest_related_tags(
+        new_text, related_text, related_tags, already_tags
+    )
+    tags_result += [t for t in related_suggestions if t not in already_tags]
+
+    return tags_result

--- a/backend/llm/generate_tags.py
+++ b/backend/llm/generate_tags.py
@@ -1,0 +1,61 @@
+from llm.utils.generator import generate_text
+from llm.utils.parser import parse_json
+
+
+def generate_tags(text: str) -> list[str]:
+    # メジャータグ抽出
+    def extract_major_tags(text: str) -> list[str]:
+        prompt = f"""
+# 指示
+あなたはメモ分類アシスタントです。
+以下のメモ本文から、該当する「メジャータグ」を**必要なだけ全て**選んでください。
+- メジャータグ：「アイデア、ヒント、日記、ToDo、旅行、食事、人間関係、イベント、買い物、予定」
+
+# 出力形式 該当がなければ空リスト
+{{"result": "タグ1, タグ2, タグ3"}}
+
+# メモ本文
+{text}
+"""
+        json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=128)
+        # parse_jsonの返り値はカンマ区切りの文字列前提
+        tag_str = parse_json(json_text)
+        if isinstance(tag_str, str):
+            tags = [t.strip() for t in tag_str.split(",") if t.strip()]
+        elif isinstance(tag_str, list):  # 念のためリスト形式にも対応
+            tags = [t.strip() for t in tag_str if t.strip()]
+        else:
+            tags = []
+        return tags
+
+    # カスタムタグ抽出
+    def extract_custom_tags(text: str) -> list[str]:
+        prompt = f"""
+# 指示
+あなたはメモ分類アシスタントです。
+以下のメモ本文から、「カスタムタグ」として本文中に現れる固有名詞や個人に紐づく表現（人名、地名、商品名、施設名、個別ワードなど）を全て抽出してください。
+
+# 出力形式 該当がなければ空リスト
+{{"result": "タグ1, タグ2, タグ3"}}
+
+# メモ本文
+{text}
+"""
+        json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=128)
+        tag_str = parse_json(json_text)
+        if isinstance(tag_str, str):
+            tags = [t.strip() for t in tag_str.split(",") if t.strip()]
+        elif isinstance(tag_str, list):
+            tags = [t.strip() for t in tag_str if t.strip()]
+        else:
+            tags = []
+        return tags
+
+    # 実装が間に合えばここに、関連メモを取得 -> プロンプトで参照 -> 新たなタグ候補を取得するプロセスを追加
+
+    # タグ取得
+    major_tags = extract_major_tags(text)
+    custom_tags = extract_custom_tags(text)
+    # 重複排除
+    all_tags = list(dict.fromkeys(major_tags + custom_tags))
+    return all_tags

--- a/backend/llm/generate_tags.py
+++ b/backend/llm/generate_tags.py
@@ -18,11 +18,10 @@ def generate_tags(text: str) -> list[str]:
 {text}
 """
         json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=128)
-        # parse_jsonの返り値はカンマ区切りの文字列前提
         tag_str = parse_json(json_text)
         if isinstance(tag_str, str):
             tags = [t.strip() for t in tag_str.split(",") if t.strip()]
-        elif isinstance(tag_str, list):  # 念のためリスト形式にも対応
+        elif isinstance(tag_str, list):
             tags = [t.strip() for t in tag_str if t.strip()]
         else:
             tags = []
@@ -33,7 +32,7 @@ def generate_tags(text: str) -> list[str]:
         prompt = f"""
 # 指示
 あなたはメモ分類アシスタントです。
-以下のメモ本文から、「カスタムタグ」として本文中に現れる固有名詞や個人に紐づく表現（人名、地名、商品名、施設名、個別ワードなど）を全て抽出してください。
+以下のメモ本文から、人名以外の固有名詞（例：地名、商品名、施設名、イベント名、キーワードなど）を「カスタムタグ」としてすべて抽出してください。
 
 # 出力形式 該当がなければ空リスト
 {{"result": "タグ1, タグ2, タグ3"}}
@@ -51,11 +50,46 @@ def generate_tags(text: str) -> list[str]:
             tags = []
         return tags
 
-    # 実装が間に合えばここに、関連メモを取得 -> プロンプトで参照 -> 新たなタグ候補を取得するプロセスを追加
+    # アイデア種別の分類
+    def classify_idea_type(text: str) -> str:
+        prompt = f"""
+# 指示
+次のメモがどの分野やカテゴリの「アイデア」か、1つの短い単語で答えてください。
+例：「アプリ」「サービス」「イベント」「商品」「仕事」「週間」「企画」「研究」「デザイン」「ストーリー」など
+該当するものがない場合は"None"を返してください。
+
+# メモ本文
+{text}
+
+# 出力形式
+例1: {{"result": "健康"}}
+例2: {{"result": "None"}}
+"""
+        json_text = generate_text(prompt, enable_thinking=False, max_new_tokens=64)
+        category = parse_json(json_text)
+        if isinstance(category, str):
+            category = category.strip()
+            # None, "None", 空文字列は除外
+            if category and category.lower() != "none":
+                return category
+        return ""
 
     # タグ取得
     major_tags = extract_major_tags(text)
+
+    # アイデアタグがあれば種別分類
+    idea_category = None
+    if "アイデア" in major_tags:
+        idea_category = classify_idea_type(text)
+
     custom_tags = extract_custom_tags(text)
+
+    # アイデア分類結果をメジャータグの次に追加
+    all_tags = major_tags.copy()
+    if idea_category and idea_category not in all_tags:
+        all_tags.append(idea_category)
+    all_tags += [tag for tag in custom_tags if tag not in all_tags]
+
     # 重複排除
-    all_tags = list(dict.fromkeys(major_tags + custom_tags))
+    all_tags = list(dict.fromkeys(all_tags))
     return all_tags

--- a/backend/tests/test_put_memo_websocket.py
+++ b/backend/tests/test_put_memo_websocket.py
@@ -28,7 +28,7 @@ def test_normal_update_websocket(test_db, client):
         assert response["status"] == "success"
         assert response["memo_id"] == memo_id
 
-        asyncio.run(asyncio.sleep(1.2))
+        asyncio.run(asyncio.sleep(3.2))
 
         websocket.close()
 


### PR DESCRIPTION
close #239 
relate #104 

## generate_tags関数の追加
メモ(body)からメジャータグおよびカスタムタグを抽出し、1つのリストとして返すgenerate_tags関数を追加しました。
本関数は内部で2つのサブ関数（extract_major_tags, extract_custom_tags）を呼び出し、それぞれLLMプロンプトを分けてタグ抽出処理を行います。
サブ関数は外部から呼び出されることがないため、generate_tags内に関数として定義しています。

- メジャータグ：所定のカテゴリから該当タグを抽出
- カスタムタグ：本文中の固有名詞等を抽出
- 両者を結合し、重複を除いたリストとして返却