### PR TITLE
feat: メモ詳細からドロワーが表示される画面まで一気に戻れるように

### DIFF
--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -7,6 +7,7 @@ import 'package:frontend/pages/errors/memo_not_found_page.dart';
 import 'package:frontend/providers/memo_edit_provider.dart';
 import 'package:frontend/providers/memo_provider.dart';
 import 'package:frontend/repositories/memo_repository/memo_repository.dart';
+import 'package:frontend/widgets/custom_back_button.dart';
 import 'package:frontend/widgets/dialogs/delete_dialog.dart';
 import 'package:frontend/widgets/dialogs/input_dialog.dart';
 import 'package:frontend/widgets/memo_details/memo_body_view.dart';
@@ -91,6 +92,7 @@ class MemoDetailsPage extends HookConsumerWidget {
             },
           ),
         ],
+        leading: const CustomBackButton(),
       ),
       floatingActionButton:
           showFab

--- a/frontend/lib/widgets/custom_back_button.dart
+++ b/frontend/lib/widgets/custom_back_button.dart
@@ -1,0 +1,19 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:frontend/router.dart';
+
+/// ドロワーが表示される画面まで一気に戻るボタン
+class CustomBackButton extends StatelessWidget {
+  const CustomBackButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BackButton(
+      onPressed: () {
+        if (!context.mounted) return;
+
+        context.router.popUntil((route) => route.data?.toDestination() != null);
+      },
+    );
+  }
+}

--- a/frontend/lib/widgets/custom_back_button.dart
+++ b/frontend/lib/widgets/custom_back_button.dart
@@ -10,8 +10,6 @@ class CustomBackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return BackButton(
       onPressed: () {
-        if (!context.mounted) return;
-
         context.router.popUntil((route) => route.data?.toDestination() != null);
       },
     );


### PR DESCRIPTION
close #261 
relate #252 
ref #219 

## 概要
- メモ詳細から関連メモを複数遷移した場合でも、戻るボタンで一気にドロワーが表示される画面まで戻れるようにしました
- MemoNotFoundみたいなエラー系のページは以前のまま直前の画面に戻れるようにしています