### PR TITLE
fix: アプリ名を「MynDly」に変更

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <!-- ここまで -->
 
     <application
-        android:label="frontend"
+        android:label="MynDly"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Frontend</string>
+	<string>MynDly</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>frontend</string>
+	<string>MynDly</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/frontend/lib/widgets/destination_navigation_drawer.dart
+++ b/frontend/lib/widgets/destination_navigation_drawer.dart
@@ -51,7 +51,7 @@ class DestinationNavigationDrawer extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.all(16),
           child: Text(
-            '瞬間メモ（仮）',
+            'MynDly',
             style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
           ),
         ),

--- a/frontend/lib/widgets/destination_navigation_drawer.dart
+++ b/frontend/lib/widgets/destination_navigation_drawer.dart
@@ -49,10 +49,12 @@ class DestinationNavigationDrawer extends StatelessWidget {
       },
       children: [
         Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(24),
           child: Text(
             'MynDly',
-            style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            style: textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
           ),
         ),
         for (final destination in Destination.values)


### PR DESCRIPTION
close #271 
relate #265

スマホ上の名前も変えています。実機で確認済みです

<img width="361" alt="image" src="https://github.com/user-attachments/assets/88958021-e41c-4e59-b11a-50bd8fdd6a58" />
