### PR TITLE
fix: タグ周りのバグ修正とダイアログ表示を一時的に無効化

### DIFF
--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -8,7 +8,6 @@ import 'package:frontend/providers/memo_edit_provider.dart';
 import 'package:frontend/providers/memo_provider.dart';
 import 'package:frontend/repositories/memo_repository/memo_repository.dart';
 import 'package:frontend/widgets/custom_back_button.dart';
-import 'package:frontend/widgets/dialogs/delete_dialog.dart';
 import 'package:frontend/widgets/dialogs/input_dialog.dart';
 import 'package:frontend/widgets/favorite_icon.dart';
 import 'package:frontend/widgets/memo_details/memo_body_view.dart';
@@ -200,17 +199,7 @@ class _TagChip extends ConsumerWidget {
       deleteIcon: const Icon(Icons.close),
       onDeleted:
           isEditingMode
-              ? () async {
-                final isDeletionSelected = await showDialog<bool>(
-                  context: context,
-                  builder: (context) {
-                    return MemoTagDeleteDialog(tagName: tagName);
-                  },
-                );
-                if (isDeletionSelected != null && isDeletionSelected) {
-                  ref.read(memoTagNamesProvider.notifier).removeTag(tagName);
-                }
-              }
+              ? () => ref.read(memoTagNamesProvider.notifier).removeTag(tagName)
               : null,
     );
   }

--- a/frontend/lib/pages/memo_details_page.dart
+++ b/frontend/lib/pages/memo_details_page.dart
@@ -199,7 +199,10 @@ class _TagChip extends ConsumerWidget {
       deleteIcon: const Icon(Icons.close),
       onDeleted:
           isEditingMode
-              ? () => ref.read(memoTagNamesProvider.notifier).removeTag(tagName)
+              ? () {
+                // TODO(tyPhoon-collab): Websocketに対応時にダイアログを表示する機構を復活させる
+                ref.read(memoTagNamesProvider.notifier).removeTag(tagName);
+              }
               : null,
     );
   }

--- a/frontend/lib/widgets/memo_details/memo_body_view.dart
+++ b/frontend/lib/widgets/memo_details/memo_body_view.dart
@@ -181,6 +181,7 @@ class _EditToolBar extends ConsumerWidget {
               IconButton.outlined(
                 icon: const Icon(Icons.close),
                 onPressed: () {
+                  ref.read(memoTagNamesProvider.notifier).setTags(memo.tags);
                   ref.read(isEditingModeProvider.notifier).toggle();
                 },
               ),

--- a/frontend/lib/widgets/memo_details/memo_body_view.dart
+++ b/frontend/lib/widgets/memo_details/memo_body_view.dart
@@ -181,6 +181,7 @@ class _EditToolBar extends ConsumerWidget {
               IconButton.outlined(
                 icon: const Icon(Icons.close),
                 onPressed: () {
+                  // もともとのメモのタグの内容にリセット
                   ref.read(memoTagNamesProvider.notifier).setTags(memo.tags);
                   ref.read(isEditingModeProvider.notifier).toggle();
                 },


### PR DESCRIPTION
close #281 
relate #280 

削除のダイアログをなくしています。（Websocket実装時には再度復活予定）

また、編集キャンセル時の挙動のバグを修正しました

https://github.com/user-attachments/assets/64f4f682-64fe-4a82-928e-f71a7230c28a

