### PR TITLE
fix: 思考空間から戻れるように

### DIFF
--- a/frontend/lib/pages/sphere_page.dart
+++ b/frontend/lib/pages/sphere_page.dart
@@ -49,63 +49,67 @@ class SpherePage extends HookConsumerWidget {
       extendBodyBehindAppBar: true,
       backgroundColor: colorScheme.surface,
       appBar: AppBar(title: const Text('思考空間')),
-      body: Stack(
-        children: [
-          GraphifyView(
-            controller: controller,
-            onConsoleMessage: (message) {
-              debugPrint('Console: $message');
-            },
-            onCreated: () {
-              isSphereLoading.value = false;
-            },
-            initialOptions: {
-              'backgroundColor': Colors.transparent.toEchartsString(),
-              'series': [
-                {
-                  'type': 'scatter3D',
-                  'symbolSize': 20,
-                  'data': data,
-                  'label': const {
-                    'show': true,
-                    'formatter': '{b}',
-                    'textStyle': {'fontSize': 10}, // 実際にデータを入れてから調整する
+      body: SafeArea(
+        child: Stack(
+          children: [
+            GraphifyView(
+              controller: controller,
+              onConsoleMessage: (message) {
+                debugPrint('Console: $message');
+              },
+              onCreated: () {
+                isSphereLoading.value = false;
+              },
+              initialOptions: {
+                'backgroundColor': Colors.transparent.toEchartsString(),
+                'series': [
+                  {
+                    'type': 'scatter3D',
+                    'symbolSize': 20,
+                    'data': data,
+                    'label': const {
+                      'show': true,
+                      'formatter': '{b}',
+                      'textStyle': {'fontSize': 10}, // 実際にデータを入れてから調整する
+                    },
+                    'itemStyle': {
+                      'color': colorScheme.primary.toEchartsString(),
+                    },
                   },
-                  'itemStyle': {'color': colorScheme.primary.toEchartsString()},
-                },
-                ...wireframe.meridianLines.map(
-                  (line) => {
-                    'type': 'line3D',
-                    'data': line,
-                    'lineStyle': lineStyle,
+                  ...wireframe.meridianLines.map(
+                    (line) => {
+                      'type': 'line3D',
+                      'data': line,
+                      'lineStyle': lineStyle,
+                    },
+                  ),
+                  ...wireframe.parallelLines.map(
+                    (line) => {
+                      'type': 'line3D',
+                      'data': line,
+                      'lineStyle': lineStyle,
+                    },
+                  ),
+                ],
+                'xAxis3D': const {'type': 'value', 'max': 1, 'min': -1},
+                'yAxis3D': const {'type': 'value', 'max': 1, 'min': -1},
+                'zAxis3D': const {'type': 'value', 'max': 1, 'min': -1},
+                'grid3D': const {
+                  'show': false,
+                  'boxWidth': 100,
+                  'boxHeight': 100,
+                  'viewControl': {
+                    'autoRotate': true,
+                    'autoRotateSpeed': 10,
+                    'distance': 250,
                   },
-                ),
-                ...wireframe.parallelLines.map(
-                  (line) => {
-                    'type': 'line3D',
-                    'data': line,
-                    'lineStyle': lineStyle,
-                  },
-                ),
-              ],
-              'xAxis3D': const {'type': 'value', 'max': 1, 'min': -1},
-              'yAxis3D': const {'type': 'value', 'max': 1, 'min': -1},
-              'zAxis3D': const {'type': 'value', 'max': 1, 'min': -1},
-              'grid3D': const {
-                'show': false,
-                'boxWidth': 100,
-                'boxHeight': 100,
-                'viewControl': {
-                  'autoRotate': true,
-                  'autoRotateSpeed': 10,
-                  'distance': 250,
                 },
               },
-            },
-          ),
-          if (isSphereLoading.value)
-            const Center(child: CircularProgressIndicator()),
-        ],
+            ),
+            if (isSphereLoading.value)
+              const Center(child: CircularProgressIndicator()),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/lib/pages/sphere_page.dart
+++ b/frontend/lib/pages/sphere_page.dart
@@ -46,7 +46,7 @@ class SpherePage extends HookConsumerWidget {
         }).toList();
 
     return Scaffold(
-      extendBodyBehindAppBar: true,
+      extendBodyBehindAppBar: !kIsWeb,
       backgroundColor: colorScheme.surface,
       appBar: AppBar(title: const Text('思考空間')),
       body: SafeArea(

--- a/frontend/lib/widgets/custom_back_button.dart
+++ b/frontend/lib/widgets/custom_back_button.dart
@@ -10,7 +10,11 @@ class CustomBackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return BackButton(
       onPressed: () {
-        context.router.popUntil((route) => route.data?.toDestination() != null);
+        context.router.popUntil((route) {
+          final destination = route.data?.toDestination();
+          // 思考空間はドロワー内に存在するが、思考空間ページにドロワーが表示されない
+          return destination != null && destination != Destination.sphere;
+        });
       },
     );
   }


### PR DESCRIPTION
close #286 
relate #285 

## 概要
- AppBarの戻るボタンが押せなくなっていたのを修正しました
- ~~本当はdrawerを表示したかったのですが、難しかったので断念しました~~
  - ~~ドロワーが表示されている時に`GraphifyView`のタップイベントを遮断する方法が見つからなかったです~~
  - ドロワーが表示されている時は地球儀を表示しないようにしてみました。Widgetの頻繁な作成・破棄がパフォーマンスに悪影響であれば、戻るボタンの表示に戻します