### PR TITLE
fix: サーバーからのused_numが反映されるように

### DIFF
--- a/frontend/lib/models/tag.dart
+++ b/frontend/lib/models/tag.dart
@@ -7,6 +7,7 @@ extension type const TagId(int value) {}
 
 @freezed
 sealed class Tag with _$Tag {
+  @JsonSerializable(fieldRename: FieldRename.snake)
   const factory Tag({
     @TagIdJsonConverter() required TagId id,
     required String name,

--- a/frontend/lib/models/tag.freezed.dart
+++ b/frontend/lib/models/tag.freezed.dart
@@ -79,8 +79,8 @@ as int,
 
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.snake)
 class _Tag implements Tag {
   const _Tag({@TagIdJsonConverter() required this.id, required this.name, this.usedNum = 0});
   factory _Tag.fromJson(Map<String, dynamic> json) => _$TagFromJson(json);

--- a/frontend/lib/models/tag.g.dart
+++ b/frontend/lib/models/tag.g.dart
@@ -9,11 +9,11 @@ part of 'tag.dart';
 _Tag _$TagFromJson(Map<String, dynamic> json) => _Tag(
   id: const TagIdJsonConverter().fromJson((json['id'] as num).toInt()),
   name: json['name'] as String,
-  usedNum: (json['usedNum'] as num?)?.toInt() ?? 0,
+  usedNum: (json['used_num'] as num?)?.toInt() ?? 0,
 );
 
 Map<String, dynamic> _$TagToJson(_Tag instance) => <String, dynamic>{
   'id': const TagIdJsonConverter().toJson(instance.id),
   'name': instance.name,
-  'usedNum': instance.usedNum,
+  'used_num': instance.usedNum,
 };


### PR DESCRIPTION
close #295 
relate #285 

## 概要
- サーバーからの `used_num` が `Tag.usedNum` に反映されるようにしました