### PR TITLE
feat: タグの回数ソート

### DIFF
--- a/backend/crud/tag.py
+++ b/backend/crud/tag.py
@@ -7,7 +7,7 @@ from models.memo import Memos
 from models.memotag import MemoTags
 from models.tag import Tags
 from models.tagembeddings import TagEmbeddings
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, desc, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -47,6 +47,8 @@ def fetch_tags_with_count(db: Session, user_id: str, search_word: Optional[str] 
 
     if search_word:
         query = query.where(Tags.name.ilike(f"%{search_word}%"))
+
+    query = query.order_by(desc("used_num"))
 
     result = db.execute(query)
 

--- a/backend/tests/test_get_tags.py
+++ b/backend/tests/test_get_tags.py
@@ -41,12 +41,11 @@ def test_normal_get(test_db, client):
 
     assert len(data) == 2
 
-    for tag in data:
-        assert tag["name"] in ["タグ1", "Tag 2"]
-        if tag["name"] == "タグ1":
-            assert tag["used_num"] == 2
-        else:
-            assert tag["used_num"] == 1
+    assert data[0]["name"] == "タグ1"
+    assert data[0]["used_num"] == 2
+
+    assert data[1]["name"] == "Tag 2"
+    assert data[1]["used_num"] == 1
 
 
 # ユーザのタグが存在しない場合に正常に通信が行われるか


### PR DESCRIPTION
close: #303 

## 実施内容
- タグ検索時にused_numでソートを自動的に使用

## 補足
- フロント側での対応は不要